### PR TITLE
fix(processx): kill the whole process group on cancel

### DIFF
--- a/internal/processx/process.go
+++ b/internal/processx/process.go
@@ -26,8 +26,12 @@ const defaultWaitDelay = 5 * time.Second
 //   - terminate (on cancel) signals the entire group/tree, not just the leader,
 //     so inherited pipes are closed and the drain unblocks.
 //
-// WaitDelay is kept as a backstop for the rare case a descendant escapes the
-// group (e.g. it called setsid itself).
+// WaitDelay only bounds the window inside cmd.Wait; it is NOT a backstop for a
+// descendant that escapes the group (e.g. by calling setsid) while still
+// holding an inherited stdout/stderr pipe. In that case clihelper's drain
+// (wg.Wait) blocks before cmd.Wait is ever reached, so WaitDelay never fires
+// and the run still hangs. That escape is a known residual risk; the group kill
+// above is what covers the common case.
 func ConfigureCancellation(cmd *exec.Cmd) {
 	if cmd == nil {
 		return

--- a/internal/processx/process.go
+++ b/internal/processx/process.go
@@ -2,35 +2,39 @@ package processx
 
 import (
 	"os/exec"
-	"runtime"
-	"strconv"
 	"time"
 )
 
 const defaultWaitDelay = 5 * time.Second
 
-// ConfigureCancellation makes exec.CommandContext cancellation less brittle
-// for local agent CLIs. On Windows the runnable command is often a PowerShell
-// or cmd shim; terminating only that wrapper can leave the real provider
-// process alive with stdout/stderr pipes open.
+// ConfigureCancellation makes exec.CommandContext cancellation reliable for
+// local agent CLIs that spawn their own child processes (for example Claude
+// Code plan-mode sub-agents, or a PowerShell/cmd shim on Windows).
+//
+// The problem it solves: drivers stream the CLI's stdout/stderr by draining the
+// pipes to EOF before calling cmd.Wait (see internal/clihelper). A child process
+// inherits those pipe file descriptors, so killing only the top-level process
+// leaves the children holding the write end open. The drain never observes EOF,
+// cmd.Wait is never reached, the driver Run never returns, and the surrounding
+// SDK run hangs — which in turn keeps the session lease held (renewed) instead
+// of releasing it. The next run on the same session key then fails with
+// ErrSessionBusy even though the user already cancelled.
+//
+// The fix has two cooperating parts:
+//   - configureProcessGroup (before Start) isolates the command so the whole
+//     process tree can be addressed together.
+//   - terminate (on cancel) signals the entire group/tree, not just the leader,
+//     so inherited pipes are closed and the drain unblocks.
+//
+// WaitDelay is kept as a backstop for the rare case a descendant escapes the
+// group (e.g. it called setsid itself).
 func ConfigureCancellation(cmd *exec.Cmd) {
 	if cmd == nil {
 		return
 	}
+	configureProcessGroup(cmd)
 	cmd.Cancel = func() error {
 		return terminate(cmd)
 	}
 	cmd.WaitDelay = defaultWaitDelay
-}
-
-func terminate(cmd *exec.Cmd) error {
-	if cmd == nil || cmd.Process == nil {
-		return nil
-	}
-	if runtime.GOOS == "windows" {
-		if err := exec.Command("taskkill.exe", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid)).Run(); err == nil {
-			return nil
-		}
-	}
-	return cmd.Process.Kill()
 }

--- a/internal/processx/process_unix.go
+++ b/internal/processx/process_unix.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package processx
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+// configureProcessGroup starts the child in a new process group so the entire
+// process tree (including agent-spawned sub-processes) can be signalled at once
+// via the negative PGID. Children inherit the group unless they deliberately
+// leave it, which is exactly what we need to reap sub-agents on cancel.
+func configureProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// terminate kills the child's whole process group. Because Setpgid makes the
+// child a group leader, its PGID equals its PID, so signalling -PGID reaches the
+// leader and every descendant that stayed in the group. This ensures inherited
+// stdout/stderr pipes are closed promptly so the driver's pipe drain reaches EOF
+// and cmd.Wait can return.
+//
+// If the group lookup or group kill fails for any reason it falls back to
+// killing just the leader, preserving the previous behaviour.
+func terminate(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	pid := cmd.Process.Pid
+	pgid, err := syscall.Getpgid(pid)
+	if err != nil {
+		pgid = pid
+	}
+	if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return cmd.Process.Kill()
+	}
+	return nil
+}

--- a/internal/processx/process_unix_test.go
+++ b/internal/processx/process_unix_test.go
@@ -1,0 +1,67 @@
+//go:build !windows
+
+package processx
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestConfigureCancellationReapsChildHoldingStdout reproduces the cancellation
+// hang: a CLI spawns a child that inherits stdout and outlives the leader. The
+// driver pattern drains stdout to EOF before Wait, so unless the whole process
+// group is killed on cancel, the child keeps the pipe open and the drain blocks
+// for the child's full lifetime.
+//
+// With the process-group fix, cancelling the context must close stdout promptly
+// (the child is killed too). Against the old single-process kill this test fails
+// by timing out, because the `sleep 30` child keeps the pipe open.
+func TestConfigureCancellationReapsChildHoldingStdout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Leader spawns a background child that inherits stdout, then the leader
+	// itself stays alive. Both must die when the group is killed.
+	cmd := exec.CommandContext(ctx, "sh", "-c", "sleep 30 & sleep 30")
+	ConfigureCancellation(cmd)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Let the process group come up before cancelling.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	eof := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, stdout)
+		close(eof)
+	}()
+
+	select {
+	case <-eof:
+		// stdout reached EOF quickly -> the child holding the pipe was reaped.
+	case <-time.After(5 * time.Second):
+		t.Fatal("stdout did not reach EOF within 5s after cancel: child process survived (process group not killed)")
+	}
+
+	_ = cmd.Wait()
+}
+
+// TestTerminateNilSafe guards the nil/unstarted paths.
+func TestTerminateNilSafe(t *testing.T) {
+	if err := terminate(nil); err != nil {
+		t.Fatalf("terminate(nil): %v", err)
+	}
+	if err := terminate(exec.Command("true")); err != nil {
+		t.Fatalf("terminate(unstarted): %v", err)
+	}
+}

--- a/internal/processx/process_windows.go
+++ b/internal/processx/process_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package processx
+
+import (
+	"os/exec"
+	"strconv"
+)
+
+// configureProcessGroup is a no-op on Windows. Tree termination is handled by
+// taskkill /T in terminate, which walks and kills the whole process tree; this
+// already covers the PowerShell/cmd shim case the original implementation
+// targeted.
+func configureProcessGroup(cmd *exec.Cmd) {}
+
+// terminate kills the whole process tree via taskkill, falling back to killing
+// just the leader if taskkill is unavailable or fails.
+func terminate(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	if err := exec.Command("taskkill.exe", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid)).Run(); err == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}


### PR DESCRIPTION
Cancelling a run only killed the top-level CLI process, leaving any child processes it spawned (e.g. Claude Code plan-mode sub-agents) alive. Those children inherit the CLI's stdout/stderr pipe fds, so the pipe never reaches EOF.

internal/clihelper drains stdout/stderr to EOF (wg.Wait) *before* calling cmd.Wait. With an orphaned child holding the pipe open, the drain blocks indefinitely, cmd.Wait is never reached (so WaitDelay never kicks in), the driver's Run never returns, and the surrounding SDK run() never returns. Because run() owns the session lease via `defer sessionPlan.release()` and the lease-renewal goroutine keeps renewing while the run is alive, the lease is held long after the user cancelled. The next run on the same SessionKey then fails with ErrSessionBusy even though the agent was "cancelled" — observable as RUN_STARTED immediately followed by RUN_ERROR "session busy".

Fix: in processx.ConfigureCancellation, start the command in its own process group (Setpgid on unix) and, on cancel, signal the whole group (kill -PGID) instead of just the leader. This reaps inherited-pipe children so the drain reaches EOF, cmd.Wait returns, run() returns, and the lease is released promptly. WaitDelay is kept as a backstop for a descendant that deliberately leaves the group (setsid).

Windows behaviour is unchanged in spirit: termination still uses `taskkill /T` to walk the whole tree; process-group setup is a no-op.

Adds a regression test that spawns a child holding stdout past the leader's lifetime and asserts stdout reaches EOF promptly after cancel (times out against the old single-process kill).