### PR TITLE
feat: add per-run model override via WithModel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,7 @@ sdk := agentadaptor.New(
 调用级 `RunOption` 当前包括：
 
 - session：`WithSession`、`WithSessionKey`、`WithContinueSession`、`WithNewSession`、`WithForkSession`
-- 运行上下文：`WithWorkspace`、`WithRuntimeServices`、`WithSkills`、`WithMCP`、`WithInstructions`
+- 运行上下文：`WithWorkspace`、`WithRuntimeServices`、`WithSkills`、`WithModel`、`WithMCP`、`WithInstructions`
 - 策略与流式：`WithRunPolicy`、`WithStreaming`、`WithoutStreaming`
 - HITL handler：`WithPermissionHandler`、`WithPlanReviewHandler`、`WithQuestionHandler`
 - 其它元数据：`WithMetadata`、`WithAgentIdentity`

--- a/claude/driver.go
+++ b/claude/driver.go
@@ -325,6 +325,10 @@ func (adapter) SyncProfileResources(ctx context.Context, cfg any, _ agentadaptor
 
 func (adapter) Run(ctx context.Context, req agentadaptor.DriverRunRequest, sink agentadaptor.EventSink) (agentadaptor.DriverRunResult, error) {
 	cfg := readConfig(req.Config)
+	// per-run WithModel overrides the binding model for this invocation only.
+	if m := strings.TrimSpace(req.ModelOverride); m != "" {
+		cfg.Model = m
+	}
 	command := cfg.Command
 	if command == "" {
 		command = "claude"
@@ -545,11 +549,6 @@ func buildClaudeExecArgs(cfg agentadaptor.ClaudeConfig, req agentadaptor.DriverR
 		}
 	}
 
-	// per-run WithModel overrides the binding model for this invocation only;
-	// Bedrock identifier filtering still applies to the overridden value.
-	if m := strings.TrimSpace(req.ModelOverride); m != "" {
-		cfg.Model = m
-	}
 	modelFlag := claudeRequestedModelFlag(cfg)
 	if req.Session != nil && req.Session.State != nil && req.Session.State.ResumeID != "" {
 		args = append(args, "--resume", req.Session.State.ResumeID)

--- a/claude/driver.go
+++ b/claude/driver.go
@@ -545,6 +545,11 @@ func buildClaudeExecArgs(cfg agentadaptor.ClaudeConfig, req agentadaptor.DriverR
 		}
 	}
 
+	// per-run WithModel overrides the binding model for this invocation only;
+	// Bedrock identifier filtering still applies to the overridden value.
+	if m := strings.TrimSpace(req.ModelOverride); m != "" {
+		cfg.Model = m
+	}
 	modelFlag := claudeRequestedModelFlag(cfg)
 	if req.Session != nil && req.Session.State != nil && req.Session.State.ResumeID != "" {
 		args = append(args, "--resume", req.Session.State.ResumeID)

--- a/claude/driver_test.go
+++ b/claude/driver_test.go
@@ -35,40 +35,6 @@ func TestBuildClaudeExecArgsIncludesPartialMessagesWhenStreaming(t *testing.T) {
 	}
 }
 
-func modelFlagValue(args []string) (string, bool) {
-	for i, a := range args {
-		if a == "--model" && i+1 < len(args) {
-			return args[i+1], true
-		}
-	}
-	return "", false
-}
-
-func TestBuildClaudeExecArgsModelOverrideWinsOverBindingModel(t *testing.T) {
-	cfg := agentadaptor.ClaudeConfig{Model: "claude-sonnet-4-6"}
-	req := agentadaptor.DriverRunRequest{ModelOverride: "claude-opus-4-1"}
-	args := buildClaudeExecArgs(cfg, req, "", false)
-	got, ok := modelFlagValue(args)
-	if !ok {
-		t.Fatalf("expected --model flag in %#v", args)
-	}
-	if got != "claude-opus-4-1" {
-		t.Fatalf("--model = %q, want per-run override claude-opus-4-1", got)
-	}
-}
-
-func TestBuildClaudeExecArgsEmptyModelOverrideKeepsBindingModel(t *testing.T) {
-	cfg := agentadaptor.ClaudeConfig{Model: "claude-sonnet-4-6"}
-	args := buildClaudeExecArgs(cfg, agentadaptor.DriverRunRequest{ModelOverride: "   "}, "", false)
-	got, ok := modelFlagValue(args)
-	if !ok {
-		t.Fatalf("expected --model flag in %#v", args)
-	}
-	if got != "claude-sonnet-4-6" {
-		t.Fatalf("--model = %q, want binding model claude-sonnet-4-6 when override is blank", got)
-	}
-}
-
 func TestDescriptorAdvertisesExpectedMCPCapabilities(t *testing.T) {
 	caps := NewAdapter().Descriptor().MCP
 	if !caps.Supported || !caps.Stdio || !caps.HTTP || !caps.SSE {

--- a/claude/driver_test.go
+++ b/claude/driver_test.go
@@ -35,6 +35,40 @@ func TestBuildClaudeExecArgsIncludesPartialMessagesWhenStreaming(t *testing.T) {
 	}
 }
 
+func modelFlagValue(args []string) (string, bool) {
+	for i, a := range args {
+		if a == "--model" && i+1 < len(args) {
+			return args[i+1], true
+		}
+	}
+	return "", false
+}
+
+func TestBuildClaudeExecArgsModelOverrideWinsOverBindingModel(t *testing.T) {
+	cfg := agentadaptor.ClaudeConfig{Model: "claude-sonnet-4-6"}
+	req := agentadaptor.DriverRunRequest{ModelOverride: "claude-opus-4-1"}
+	args := buildClaudeExecArgs(cfg, req, "", false)
+	got, ok := modelFlagValue(args)
+	if !ok {
+		t.Fatalf("expected --model flag in %#v", args)
+	}
+	if got != "claude-opus-4-1" {
+		t.Fatalf("--model = %q, want per-run override claude-opus-4-1", got)
+	}
+}
+
+func TestBuildClaudeExecArgsEmptyModelOverrideKeepsBindingModel(t *testing.T) {
+	cfg := agentadaptor.ClaudeConfig{Model: "claude-sonnet-4-6"}
+	args := buildClaudeExecArgs(cfg, agentadaptor.DriverRunRequest{ModelOverride: "   "}, "", false)
+	got, ok := modelFlagValue(args)
+	if !ok {
+		t.Fatalf("expected --model flag in %#v", args)
+	}
+	if got != "claude-sonnet-4-6" {
+		t.Fatalf("--model = %q, want binding model claude-sonnet-4-6 when override is blank", got)
+	}
+}
+
 func TestDescriptorAdvertisesExpectedMCPCapabilities(t *testing.T) {
 	caps := NewAdapter().Descriptor().MCP
 	if !caps.Supported || !caps.Stdio || !caps.HTTP || !caps.SSE {

--- a/claude/run_session_test.go
+++ b/claude/run_session_test.go
@@ -199,6 +199,52 @@ func TestClaudeResumeProfileMismatchDoesNotWriteProfileResources(t *testing.T) {
 	}
 }
 
+func TestClaudeRunModelOverrideReflectedInReportedModel(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home := t.TempDir()
+	workspace := filepath.Join(home, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	command := testutil.WriteCommand(t, home, "fake-claude-model",
+		"#!/bin/sh\nset -eu\ncat >/dev/null\nprintf '{\"event\":\"turn.completed\",\"session_id\":\"claude-session\"}\\n'\n",
+		"@echo off\r\nsetlocal\r\nset /p PROMPT=\r\necho {\"event\":\"turn.completed\",\"session_id\":\"claude-session\"}\r\n",
+	)
+	newReq := func(override string) agentadaptor.DriverRunRequest {
+		return agentadaptor.DriverRunRequest{
+			Prompt: "hello",
+			Config: agentadaptor.ClaudeConfig{
+				CommonConfig: agentadaptor.CommonConfig{
+					Command: command,
+					CWD:     workspace,
+					Env:     []agentadaptor.EnvBinding{{Name: "HOME", Value: home}, {Name: "USERPROFILE", Value: home}},
+				},
+				Model: "claude-sonnet-4-6",
+			},
+			Workspace:     agentadaptor.WorkspaceLease{ID: "workspace-a", CWD: workspace},
+			ModelOverride: override,
+		}
+	}
+
+	// per-run override must drive both the --model flag and the reported model.
+	overridden, err := NewAdapter().Run(context.Background(), newReq("claude-opus-4-1"), &testutil.EventRecorder{})
+	if err != nil {
+		t.Fatalf("run with override: %v", err)
+	}
+	if overridden.Model != "claude-opus-4-1" {
+		t.Fatalf("reported Model = %q, want per-run override claude-opus-4-1", overridden.Model)
+	}
+
+	// blank override falls back to the binding model.
+	fallback, err := NewAdapter().Run(context.Background(), newReq("   "), &testutil.EventRecorder{})
+	if err != nil {
+		t.Fatalf("run without override: %v", err)
+	}
+	if fallback.Model != "claude-sonnet-4-6" {
+		t.Fatalf("reported Model = %q, want binding model claude-sonnet-4-6 when override is blank", fallback.Model)
+	}
+}
+
 func TestClaudeRunOmitsAnthropicModelFlagInBedrockMode(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 	home := t.TempDir()

--- a/codex/driver.go
+++ b/codex/driver.go
@@ -343,6 +343,10 @@ func (adapter) StreamCapability() agentadaptor.StreamCapability {
 
 func (adapter) Run(ctx context.Context, req agentadaptor.DriverRunRequest, sink agentadaptor.EventSink) (agentadaptor.DriverRunResult, error) {
 	cfg := readConfig(req.Config)
+	// per-run WithModel overrides the binding model for this invocation only.
+	if m := strings.TrimSpace(req.ModelOverride); m != "" {
+		cfg.Model = m
+	}
 	command := cfg.Command
 	if command == "" {
 		command = "codex"

--- a/cursor/driver.go
+++ b/cursor/driver.go
@@ -320,6 +320,10 @@ func (adapter) SyncProfileResources(ctx context.Context, cfg any, _ agentadaptor
 
 func (adapter) Run(ctx context.Context, req agentadaptor.DriverRunRequest, sink agentadaptor.EventSink) (agentadaptor.DriverRunResult, error) {
 	cfg := readConfig(req.Config)
+	// per-run WithModel overrides the binding model for this invocation only.
+	if m := strings.TrimSpace(req.ModelOverride); m != "" {
+		cfg.Model = m
+	}
 	command := cfg.Command
 	if command == "" {
 		command = "agent"

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -69,6 +69,13 @@ Context and injection:
 - `WithAgents(specs...)`
 - `WithHooks(specs...)`
 - `WithProfileConfig(patches...)`
+- `WithModel(model)` — per-run model override. Forwarded to the adapter as
+  `DriverRunRequest.ModelOverride` and supersedes the binding model
+  (`CodexConfig.Model` / `ClaudeConfig.Model` / `CursorConfig.Model`) for the
+  built-in `--model` flag on this run only. Unlike `WithProfileConfig` it does
+  not persist anything to the profile on disk and applies uniformly across
+  drivers regardless of any `model` profile-config capability. Blank values are
+  ignored (binding model stays in effect).
 - `WithInstructions(ref)`
 - `WithMetadata(key, value)`
 - `WithAgentIdentity(identity)`

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -76,6 +76,7 @@ result, err := sdk.Run(
 - `WithForkSession`
 - `WithWorkspace`
 - `WithSkills`
+- `WithModel`（per-run 覆盖 binding 模型，喂给内置 driver 的 `--model`，不落盘、对三种 driver 一致）
 - `WithMCP`
 - `WithRunPolicy`
 - `WithInstructions`

--- a/options.go
+++ b/options.go
@@ -338,6 +338,7 @@ type runOptions struct {
 	agents          *AgentPayload
 	hooks           *HookPayload
 	profileConfig   *ProfileConfigPayload
+	model           string
 	runPolicy       *RunPolicy
 	instructions    *InstructionsBundleRef
 	instructionsSet bool
@@ -527,6 +528,23 @@ func WithHooks(specs ...HookSpec) RunOption {
 func WithProfileConfig(patches ...ProfileConfigPatch) RunOption {
 	return func(ro *runOptions) {
 		ro.profileConfig = &ProfileConfigPayload{Patches: cloneProfileConfigPatches(patches)}
+	}
+}
+
+// WithModel overrides the bound agent's model for one run. It is the per-run
+// counterpart to the binding-level model carried by CodexConfig.Model /
+// ClaudeConfig.Model / CursorConfig.Model: the value is forwarded to the
+// adapter's native model selection (the `--model` flag for the built-in
+// codex / claude / cursor adapters) and takes precedence over the binding
+// model for this invocation only.
+//
+// Unlike WithProfileConfig, it does not persist anything to the agent profile
+// on disk and works uniformly across drivers regardless of whether the driver
+// exposes a "model" profile-config capability. An empty or whitespace-only
+// value is ignored, leaving the binding model in effect.
+func WithModel(model string) RunOption {
+	return func(ro *runOptions) {
+		ro.model = model
 	}
 }
 

--- a/run_model_override_test.go
+++ b/run_model_override_test.go
@@ -1,0 +1,67 @@
+package agentadaptor_test
+
+import (
+	"context"
+	"testing"
+
+	agentadaptor "github.com/agent-dance/agent-adaptor"
+)
+
+// modelCapturingDriver records the DriverRunRequest it last received so tests
+// can assert how per-run options are threaded into the adapter.
+type modelCapturingDriver struct {
+	lastReq agentadaptor.DriverRunRequest
+}
+
+func (d *modelCapturingDriver) Descriptor() agentadaptor.DriverDescriptor {
+	return agentadaptor.DriverDescriptor{Type: "model-capture", DisplayName: "Model Capture"}
+}
+
+func (d *modelCapturingDriver) ValidateConfig(any) error { return nil }
+
+func (d *modelCapturingDriver) Run(_ context.Context, req agentadaptor.DriverRunRequest, _ agentadaptor.EventSink) (agentadaptor.DriverRunResult, error) {
+	d.lastReq = req
+	return agentadaptor.DriverRunResult{Output: "ok", ExitCode: 0}, nil
+}
+
+func newModelCaptureSDK(driver agentadaptor.DriverAdapter) agentadaptor.SDK {
+	return agentadaptor.New(
+		agentadaptor.WithDefaultAgent(agentadaptor.Bind(driver, fakeConfig{Label: "model"})),
+	)
+}
+
+func TestWithModelThreadsModelOverride(t *testing.T) {
+	driver := &modelCapturingDriver{}
+	sdk := newModelCaptureSDK(driver)
+
+	if _, err := sdk.Run(context.Background(), "hi", agentadaptor.WithModel("gpt-5.4")); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := driver.lastReq.ModelOverride; got != "gpt-5.4" {
+		t.Fatalf("ModelOverride = %q, want gpt-5.4", got)
+	}
+}
+
+func TestWithModelTrimsWhitespaceToNoOverride(t *testing.T) {
+	driver := &modelCapturingDriver{}
+	sdk := newModelCaptureSDK(driver)
+
+	if _, err := sdk.Run(context.Background(), "hi", agentadaptor.WithModel("   ")); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := driver.lastReq.ModelOverride; got != "" {
+		t.Fatalf("ModelOverride = %q, want empty for whitespace-only model", got)
+	}
+}
+
+func TestRunWithoutWithModelLeavesOverrideEmpty(t *testing.T) {
+	driver := &modelCapturingDriver{}
+	sdk := newModelCaptureSDK(driver)
+
+	if _, err := sdk.Run(context.Background(), "hi"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := driver.lastReq.ModelOverride; got != "" {
+		t.Fatalf("ModelOverride = %q, want empty when WithModel is not used", got)
+	}
+}

--- a/run_types.go
+++ b/run_types.go
@@ -229,6 +229,13 @@ type DriverRunRequest struct {
 	Session        *DriverSessionContext
 	Metadata       map[string]string
 
+	// ModelOverride is the per-run model selected via WithModel. When
+	// non-empty it supersedes the binding model carried by Config for this
+	// invocation; adapters must prefer it over their Config model when
+	// resolving the provider-native model selection. Empty means "no
+	// override" and the adapter falls back to the binding model.
+	ModelOverride string
+
 	// Streaming is a hint from the host that the caller wants structured
 	// stream events (StreamPayload) emitted via EventSink.EmitStream in
 	// addition to the regular RunEvent channel. Adapters that implement
@@ -426,6 +433,7 @@ type resolvedInvocation struct {
 	metadata       map[string]string
 	fingerprint    string
 	streaming      bool
+	model          string
 }
 
 // StreamKind enumerates the protocol-agnostic streaming events adapters emit

--- a/runner.go
+++ b/runner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -454,6 +455,7 @@ func (r *runnerImpl) resolveInvocation(ctx context.Context, prompt string, opts 
 		r.binding.Adapter().Descriptor().Type,
 		identity,
 		extractDriverFingerprint(config),
+		strings.TrimSpace(resolvedOpts.model),
 		workspace.Fingerprint,
 		runtimePayload.Fingerprint,
 		profilePayload.Fingerprint,
@@ -478,6 +480,7 @@ func (r *runnerImpl) resolveInvocation(ctx context.Context, prompt string, opts 
 		metadata:       cloneStringMap(metadata),
 		fingerprint:    fingerprint,
 		streaming:      streaming,
+		model:          strings.TrimSpace(resolvedOpts.model),
 	}, cleanup, nil
 }
 
@@ -509,6 +512,7 @@ func (r *runnerImpl) executeWithSessionPlan(
 		RunID:          invocation.runID,
 		Prompt:         invocation.prompt,
 		Config:         invocation.config,
+		ModelOverride:  invocation.model,
 		Agent:          invocation.agent,
 		Workspace:      invocation.workspace,
 		Runtime:        cloneRuntimePayload(invocation.runtime),


### PR DESCRIPTION
## Summary

Adds `WithModel(model string) RunOption` so hosts can switch the model for a single run, as the per-run counterpart to the binding-level model (`CodexConfig.Model` / `ClaudeConfig.Model` / `CursorConfig.Model`).

### Why

Today the only per-run lever that touches the model is `WithProfileConfig`, which persists the model into the provider-native profile file (`settings.json` for claude, `config.toml` for codex). That approach has two problems:

1. **It is silently overridden when a binding model is set.** The binding model is forwarded as the `--model` CLI flag, and `--model` overrides the profile file. So whenever the binding has a model (the common case), the per-run profile-config model patch has no effect.
2. **It is not portable.** Drivers without a `model` profile-config capability (cursor) reject the patch as `unsupported`, so callers must special-case per driver.

Root cause: `Model` lives in the driver-specific config (not `CommonConfig`), so the generic runner had no place to express a per-run model override except the profile-config layer.

### What

- `WithModel(string)` -> `runOptions.model`.
- New `DriverRunRequest.ModelOverride` carries the value to adapters; included in the run fingerprint.
- codex / claude / cursor resolve `--model` as `override > binding cfg.Model`. Blank/whitespace override is ignored. Claude keeps its Bedrock identifier filtering on the overridden value.
- No change to `CommonConfig` or the typed config structs, so existing `XxxConfig{Model: ...}` callers are unaffected (non-breaking).
- Docs updated in `docs/api-reference.md` and `docs/usage-guide.md`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./ ./claude/... ./codex/... ./cursor/...` (green)
- New tests:
  - `run_model_override_test.go`: `WithModel` threads into `DriverRunRequest.ModelOverride`; whitespace-only is ignored; omitting it leaves the override empty.
  - `claude/driver_test.go`: `--model` uses the per-run override over the binding model; blank override falls back to the binding model.
- Note: two pre-existing failures in `internal/skillruntime` (external symlink reconciliation) also fail on `main` in this environment and are unrelated to this change.