### PR TITLE
WIP: 修复 Claude 工具调用流式事件

### DIFF
--- a/claude/parser.go
+++ b/claude/parser.go
@@ -427,6 +427,9 @@ func (p *claudeParser) handleAssistantMessage(message map[string]any) {
 		case "tool_use":
 			name := claudeTopLevelString(block, "name")
 			id := claudeTopLevelString(block, "id", "tool_use_id")
+			if p.stream != nil {
+				p.stream.handleAssistantToolUse(block)
+			}
 			if kind, interactive := claudeInteractiveTools[name]; interactive && id != "" {
 				p.registerPendingHITL(id, name, kind, block["input"])
 			}

--- a/claude/streaming_parser.go
+++ b/claude/streaming_parser.go
@@ -13,37 +13,41 @@ import (
 // API-shaped) into StreamPayload. It does not participate in checkpoint
 // construction; session capture stays in the main parser.
 type streamingState struct {
-	sink    agentadaptor.EventSink
-	runID   string
-	parser  *claudeParser
-	messageID   string
-	textStarted map[int]bool
-	blockKind   map[int]string
-	toolCallID  map[int]string
-	toolName    map[int]string
-	thinkingID  map[int]string
-	signatures  map[int]string
+	sink              agentadaptor.EventSink
+	runID             string
+	parser            *claudeParser
+	messageID         string
+	textStarted       map[int]bool
+	blockKind         map[int]string
+	toolCallID        map[int]string
+	toolName          map[int]string
+	emitToolLifecycle map[int]bool
+	emittedToolCalls  map[string]struct{}
+	thinkingID        map[int]string
+	signatures        map[int]string
 
-	runStarted       bool
-	finishedEmitted  bool
-	apiRetryHits     int
-	lastRetryWas5xx  bool
-	streamUsage      *agentadaptor.Usage
-	stopReason       string
-	numTurns         int
+	runStarted      bool
+	finishedEmitted bool
+	apiRetryHits    int
+	lastRetryWas5xx bool
+	streamUsage     *agentadaptor.Usage
+	stopReason      string
+	numTurns        int
 }
 
 func newStreamingState(sink agentadaptor.EventSink, runID string, p *claudeParser) *streamingState {
 	return &streamingState{
-		sink:        sink,
-		runID:       runID,
-		parser:      p,
-		textStarted: make(map[int]bool),
-		blockKind:   make(map[int]string),
-		toolCallID:  make(map[int]string),
-		toolName:    make(map[int]string),
-		thinkingID:  make(map[int]string),
-		signatures:  make(map[int]string),
+		sink:              sink,
+		runID:             runID,
+		parser:            p,
+		textStarted:       make(map[int]bool),
+		blockKind:         make(map[int]string),
+		toolCallID:        make(map[int]string),
+		toolName:          make(map[int]string),
+		emitToolLifecycle: make(map[int]bool),
+		emittedToolCalls:  make(map[string]struct{}),
+		thinkingID:        make(map[int]string),
+		signatures:        make(map[int]string),
 	}
 }
 
@@ -212,14 +216,17 @@ func (s *streamingState) handleContentBlockStart(event map[string]any) {
 		name := claudeTopLevelString(block, "name")
 		s.toolCallID[idx] = id
 		s.toolName[idx] = name
-		pl := s.basePayload()
-		pl.Kind = agentadaptor.StreamToolCallStart
-		pl.ToolCallID = id
-		pl.Name = name
-		if input := block["input"]; input != nil {
-			pl.Args = map[string]any{"input": input}
+		s.emitToolLifecycle[idx] = s.markToolCallEmitted(id)
+		if s.emitToolLifecycle[idx] {
+			pl := s.basePayload()
+			pl.Kind = agentadaptor.StreamToolCallStart
+			pl.ToolCallID = id
+			pl.Name = name
+			if input, ok := block["input"].(map[string]any); ok && len(input) > 0 {
+				pl.Args = cloneMapShallow(input)
+			}
+			s.emitStream(pl)
 		}
-		s.emitStream(pl)
 		// Interactive mode: register this tool_use with the parent parser
 		// so handleContentBlockDelta can accumulate input_json_delta and
 		// handleContentBlockStop can drive the HITL flow.
@@ -276,11 +283,14 @@ func (s *streamingState) handleContentBlockDelta(event map[string]any) {
 		if tid == "" {
 			tid = fmt.Sprintf("idx-%d", idx)
 		}
-		pl := s.basePayload()
-		pl.Kind = agentadaptor.StreamToolCallArgs
-		pl.ToolCallID = tid
-		pl.Delta = raw
-		s.emitStream(pl)
+		if s.emitToolLifecycle[idx] {
+			pl := s.basePayload()
+			pl.Kind = agentadaptor.StreamToolCallArgs
+			pl.ToolCallID = tid
+			pl.Name = s.toolName[idx]
+			pl.Delta = raw
+			s.emitStream(pl)
+		}
 		// Interactive mode: feed the partial_json into the accumulator so
 		// we have the complete tool_use input once content_block_stop hits.
 		if s.parser != nil {
@@ -327,7 +337,7 @@ func (s *streamingState) handleContentBlockStop(event map[string]any) {
 		}
 	case "tool_use":
 		tid := s.toolCallID[idx]
-		if tid != "" {
+		if tid != "" && s.emitToolLifecycle[idx] {
 			pl := s.basePayload()
 			pl.Kind = agentadaptor.StreamToolCallEnd
 			pl.ToolCallID = tid
@@ -357,8 +367,42 @@ func (s *streamingState) handleContentBlockStop(event map[string]any) {
 	delete(s.textStarted, idx)
 	delete(s.toolCallID, idx)
 	delete(s.toolName, idx)
+	delete(s.emitToolLifecycle, idx)
 	delete(s.thinkingID, idx)
 	delete(s.signatures, idx)
+}
+
+func (s *streamingState) handleAssistantToolUse(block map[string]any) {
+	id := claudeTopLevelString(block, "id", "tool_use_id")
+	if id == "" || !s.markToolCallEmitted(id) {
+		return
+	}
+
+	s.markRunStarted()
+	start := s.basePayload()
+	start.Kind = agentadaptor.StreamToolCallStart
+	start.ToolCallID = id
+	start.Name = claudeTopLevelString(block, "name")
+	if input, ok := block["input"].(map[string]any); ok && len(input) > 0 {
+		start.Args = cloneMapShallow(input)
+	}
+	s.emitStream(start)
+
+	end := s.basePayload()
+	end.Kind = agentadaptor.StreamToolCallEnd
+	end.ToolCallID = id
+	s.emitStream(end)
+}
+
+func (s *streamingState) markToolCallEmitted(id string) bool {
+	if id == "" {
+		return true
+	}
+	if _, ok := s.emittedToolCalls[id]; ok {
+		return false
+	}
+	s.emittedToolCalls[id] = struct{}{}
+	return true
 }
 
 func (s *streamingState) handleMessageDelta(event map[string]any) {
@@ -410,8 +454,8 @@ func (s *streamingState) handleUserToolResult(block map[string]any) {
 	pl.Kind = agentadaptor.StreamToolCallResult
 	pl.ToolCallID = id
 	pl.Result = map[string]any{
-		"text":      text,
-		"is_error":  isError,
+		"text":        text,
+		"is_error":    isError,
 		"tool_use_id": id,
 	}
 	s.emitStream(pl)
@@ -492,7 +536,7 @@ func (s *streamingState) finalize() {
 				s.emitStream(pl)
 			}
 		case "tool_use":
-			if tid := s.toolCallID[idx]; tid != "" {
+			if tid := s.toolCallID[idx]; tid != "" && s.emitToolLifecycle[idx] {
 				pl := s.basePayload()
 				pl.Kind = agentadaptor.StreamToolCallEnd
 				pl.ToolCallID = tid
@@ -511,6 +555,8 @@ func (s *streamingState) finalize() {
 	s.textStarted = nil
 	s.toolCallID = nil
 	s.toolName = nil
+	s.emitToolLifecycle = nil
+	s.emittedToolCalls = nil
 	s.thinkingID = nil
 	s.signatures = nil
 

--- a/claude/streaming_parser_test.go
+++ b/claude/streaming_parser_test.go
@@ -131,26 +131,23 @@ func TestStreamingToolFixture_ArgsFragmentsConcatenateToJSON(t *testing.T) {
 	p.finalize()
 
 	var argFragments strings.Builder
-	sawStart, sawEnd, sawResult := false, false, false
+	counts := map[agentadaptor.StreamKind]int{}
 	for _, pl := range sink.snapshot() {
+		if pl.ToolCallID != "tool-stream-1" {
+			continue
+		}
+		counts[pl.Kind]++
 		if pl.Kind == agentadaptor.StreamToolCallArgs {
 			argFragments.WriteString(pl.Delta)
 		}
-		if pl.Kind == agentadaptor.StreamToolCallStart && pl.ToolCallID == "tool-stream-1" {
-			sawStart = true
-		}
-		if pl.Kind == agentadaptor.StreamToolCallEnd && pl.ToolCallID == "tool-stream-1" {
-			sawEnd = true
-		}
-		if pl.Kind == agentadaptor.StreamToolCallResult && pl.ToolCallID == "tool-stream-1" {
-			sawResult = true
+		if pl.Kind == agentadaptor.StreamToolCallResult {
 			if pl.Result == nil || pl.Result["is_error"] != false {
 				t.Fatalf("tool result: %+v", pl.Result)
 			}
 		}
 	}
-	if !sawStart || !sawEnd || !sawResult {
-		t.Fatalf("tool lifecycle start=%v end=%v result=%v", sawStart, sawEnd, sawResult)
+	if counts[agentadaptor.StreamToolCallStart] != 1 || counts[agentadaptor.StreamToolCallEnd] != 1 || counts[agentadaptor.StreamToolCallResult] != 1 {
+		t.Fatalf("tool lifecycle must not duplicate full assistant replay: %+v", counts)
 	}
 
 	input := map[string]any{"path": "/tmp/x"}
@@ -163,6 +160,142 @@ func TestStreamingToolFixture_ArgsFragmentsConcatenateToJSON(t *testing.T) {
 	if !reflect.DeepEqual(gotObj, wantObj) {
 		t.Fatalf("args concat decode: got %#v want %#v (raw concat %q)", gotObj, wantObj, argFragments.String())
 	}
+}
+
+func TestStreamingCompleteAssistantToolUseEmitsLifecycle(t *testing.T) {
+	fixture := loadFixture(t, "streaming-nonstream-tool-use.jsonl")
+	sink := &streamSink{}
+	p := newClaudeParser(sink)
+	p.enableStreaming("run-complete-tools")
+
+	if err := p.onChunk("stdout", fixture, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	p.finalize()
+
+	want := map[string]struct {
+		name string
+		args map[string]any
+	}{
+		"tool-read-1": {
+			name: "Read",
+			args: map[string]any{"file_path": "/tmp/a.go"},
+		},
+		"tool-grep-1": {
+			name: "Grep",
+			args: map[string]any{"pattern": "TODO", "path": "/tmp"},
+		},
+	}
+	counts := map[string]map[agentadaptor.StreamKind]int{}
+	sequences := map[string][]agentadaptor.StreamKind{}
+	for _, pl := range sink.snapshot() {
+		expected, ok := want[pl.ToolCallID]
+		if !ok {
+			continue
+		}
+		if counts[pl.ToolCallID] == nil {
+			counts[pl.ToolCallID] = map[agentadaptor.StreamKind]int{}
+		}
+		counts[pl.ToolCallID][pl.Kind]++
+		switch pl.Kind {
+		case agentadaptor.StreamToolCallStart, agentadaptor.StreamToolCallEnd, agentadaptor.StreamToolCallResult:
+			sequences[pl.ToolCallID] = append(sequences[pl.ToolCallID], pl.Kind)
+		}
+		if pl.Kind == agentadaptor.StreamToolCallStart {
+			if pl.Name != expected.name || !reflect.DeepEqual(pl.Args, expected.args) {
+				t.Fatalf("tool start %s: got name=%q args=%#v want name=%q args=%#v", pl.ToolCallID, pl.Name, pl.Args, expected.name, expected.args)
+			}
+		}
+	}
+
+	for id := range want {
+		got := counts[id]
+		if got[agentadaptor.StreamToolCallStart] != 1 || got[agentadaptor.StreamToolCallEnd] != 1 || got[agentadaptor.StreamToolCallResult] != 1 {
+			t.Errorf("tool lifecycle %s: %+v", id, got)
+		}
+		if got[agentadaptor.StreamToolCallArgs] != 0 {
+			t.Errorf("complete tool use %s emitted synthetic args deltas: %+v", id, got)
+		}
+		wantSequence := []agentadaptor.StreamKind{
+			agentadaptor.StreamToolCallStart,
+			agentadaptor.StreamToolCallEnd,
+			agentadaptor.StreamToolCallResult,
+		}
+		if !reflect.DeepEqual(sequences[id], wantSequence) {
+			t.Errorf("tool lifecycle sequence %s: got %v want %v", id, sequences[id], wantSequence)
+		}
+	}
+}
+
+func TestStreamingMCPToolUseEmitsNamedArgumentDeltas(t *testing.T) {
+	fixture := loadFixture(t, "streaming-mcp-tool-use.jsonl")
+	sink := &streamSink{}
+	p := newClaudeParser(sink)
+	p.enableStreaming("run-mcp-tool")
+
+	if err := p.onChunk("stdout", fixture, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	p.finalize()
+
+	const (
+		toolCallID = "tool-mcp-1"
+		toolName   = "mcp__docs__search"
+	)
+	counts := map[agentadaptor.StreamKind]int{}
+	var argFragments strings.Builder
+	for _, pl := range sink.snapshot() {
+		if pl.ToolCallID != toolCallID {
+			continue
+		}
+		counts[pl.Kind]++
+		switch pl.Kind {
+		case agentadaptor.StreamToolCallStart:
+			if pl.Name != toolName || len(pl.Args) != 0 {
+				t.Fatalf("MCP start: name=%q args=%#v", pl.Name, pl.Args)
+			}
+		case agentadaptor.StreamToolCallArgs:
+			if pl.Name != toolName {
+				t.Fatalf("MCP args name: got %q want %q", pl.Name, toolName)
+			}
+			argFragments.WriteString(pl.Delta)
+		}
+	}
+
+	if counts[agentadaptor.StreamToolCallStart] != 1 || counts[agentadaptor.StreamToolCallEnd] != 1 || counts[agentadaptor.StreamToolCallResult] != 1 {
+		t.Fatalf("MCP tool lifecycle: %+v", counts)
+	}
+	want := map[string]any{"query": "streaming tool arguments", "limit": float64(5)}
+	if got := decodeJSONFlexible(argFragments.String()); !reflect.DeepEqual(got, want) {
+		t.Fatalf("MCP args: got %#v want %#v raw=%q", got, want, argFragments.String())
+	}
+}
+
+func TestStreamingToolStartCarriesUnwrappedInputSnapshot(t *testing.T) {
+	sink := &streamSink{}
+	p := newClaudeParser(sink)
+	p.enableStreaming("run-tool-snapshot")
+	p.stream.handleContentBlockStart(map[string]any{
+		"index": float64(0),
+		"content_block": map[string]any{
+			"type":  "tool_use",
+			"id":    "tool-snapshot-1",
+			"name":  "Agent",
+			"input": map[string]any{"subagent_type": "Explore"},
+		},
+	})
+
+	for _, pl := range sink.snapshot() {
+		if pl.Kind != agentadaptor.StreamToolCallStart {
+			continue
+		}
+		want := map[string]any{"subagent_type": "Explore"}
+		if !reflect.DeepEqual(pl.Args, want) {
+			t.Fatalf("tool start args: got %#v want %#v", pl.Args, want)
+		}
+		return
+	}
+	t.Fatal("missing tool-call start")
 }
 
 func decodeJSONFlexible(s string) map[string]any {

--- a/claude/testdata/streaming-mcp-tool-use.jsonl
+++ b/claude/testdata/streaming-mcp-tool-use.jsonl
@@ -1,0 +1,9 @@
+{"type":"system","subtype":"init","session_id":"sess-mcp-tool","model":"claude-fixture"}
+{"type":"stream_event","session_id":"sess-mcp-tool","event":{"type":"message_start","message":{"id":"msg-mcp-1"}}}
+{"type":"stream_event","session_id":"sess-mcp-tool","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool-mcp-1","name":"mcp__docs__search","input":{}}}}
+{"type":"stream_event","session_id":"sess-mcp-tool","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"streaming tool arguments\","}}}
+{"type":"stream_event","session_id":"sess-mcp-tool","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"limit\":5}"}}}
+{"type":"stream_event","session_id":"sess-mcp-tool","event":{"type":"content_block_stop","index":0}}
+{"type":"assistant","session_id":"sess-mcp-tool","message":{"content":[{"type":"tool_use","id":"tool-mcp-1","name":"mcp__docs__search","input":{"query":"streaming tool arguments","limit":5}}]}}
+{"type":"user","session_id":"sess-mcp-tool","message":{"content":[{"type":"tool_result","tool_use_id":"tool-mcp-1","content":"match"}]}}
+{"type":"result","subtype":"success","session_id":"sess-mcp-tool","result":"MCP finished."}

--- a/claude/testdata/streaming-nonstream-tool-use.jsonl
+++ b/claude/testdata/streaming-nonstream-tool-use.jsonl
@@ -1,0 +1,4 @@
+{"type":"system","subtype":"init","session_id":"sess-complete-tools","model":"claude-fixture"}
+{"type":"assistant","session_id":"sess-complete-tools","parent_tool_use_id":"tool-parent-explore","message":{"content":[{"type":"tool_use","id":"tool-read-1","name":"Read","input":{"file_path":"/tmp/a.go"}},{"type":"tool_use","id":"tool-grep-1","name":"Grep","input":{"pattern":"TODO","path":"/tmp"}}]}}
+{"type":"user","session_id":"sess-complete-tools","parent_tool_use_id":"tool-parent-explore","message":{"content":[{"type":"tool_result","tool_use_id":"tool-read-1","content":"package example"},{"type":"tool_result","tool_use_id":"tool-grep-1","content":"/tmp/a.go:1: TODO"}]}}
+{"type":"result","subtype":"success","session_id":"sess-complete-tools","result":"Explore finished."}

--- a/fix-claude-non-stream-tool-calls.md
+++ b/fix-claude-non-stream-tool-calls.md
@@ -1,0 +1,93 @@
+---
+scope: claude-streaming
+status: approved
+references:
+  - AGENTS.md
+  - claude/parser.go
+  - claude/streaming_parser.go
+  - claude/streaming_parser_test.go
+---
+
+# 补齐 Claude 工具调用生命周期、参数与 SubAgent 标题
+
+## 目标
+
+让所有经 Claude 输出的工具调用都向 `StreamPayload` 输出完整的生命周期和参数，使下游前端能直接聚合卡片；同时让 FlowX Viewer 根据真实参数显示具体 SubAgent 名称。Explore 是当前已确认的触发场景。
+
+## 背景
+
+Claude CLI 对普通工具调用会输出 `stream_event.content_block_start` 和 `input_json_delta`，adapter 已将其转换为完整工具调用生命周期。
+
+Explore 内部工具调用会以非流式 `assistant.message.content[].tool_use` 出现。任何 Claude 工具调用出现这种形态时，当前 `handleAssistantMessage` 都只写 `TranscriptToolCall`，没有调用 `EmitStream`。后续 `user.message.content[].tool_result` 仍会被 `handleUserMessage` 转为 `StreamToolCallResult`，因此前端只有结果，没有名称和入参。
+
+下游 FlowX 会原样转发 `StreamPayload`，但 Viewer 当前不读取 `tool_call.start.Args`，也只会把 SubAgent 显示成 Claude 的原始工具名 `Agent`。AG-UI translator 同样会忽略 start 上的完整 Args，因此需要补齐转换降级逻辑。
+
+## 终态方案
+
+在 `agent-adaptor` 的 Claude streaming parser 中补齐非流式 tool_use fallback：
+
+1. `handleAssistantMessage` 发现 `tool_use` 且 streaming 已启用时，调用 streaming state 的 fallback 方法。
+2. fallback 以完整 `input` 发出 `StreamToolCallStart`，设置 `ToolCallID`、`Name` 和 `Args`，紧接着发出 `StreamToolCallEnd`。
+3. 既有 `handleUserToolResult` 不变，继续发出同一 `ToolCallID` 的 `StreamToolCallResult`。
+4. streaming state 记录已见 tool call ID，普通 `stream_event` 与 fallback 共享这一去重状态，保证同一工具调用不会重复发 start/end。
+5. `input_json_delta` 参数事件带上原始工具名；完整 `assistant.tool_use.input` 原样写入 `StreamToolCallStart.Args`，不额外包装 `input`。
+6. AG-UI translator 暂存 start 上的完整 Args：若后续没有 delta，则在 end 前补发一次 `TOOL_CALL_ARGS`；若收到 delta，则保持既有 delta 流并丢弃快照，避免把完整 JSON 与参数/命令输出 delta 拼成无效 AG-UI args。
+7. FlowX Viewer 同时消费 start 快照和 args 增量；有完整 start Args 时把后续 delta 单独显示为 output。参数 JSON 完整后，根据 `subagent_type` 把 `Agent` / `Task` 卡片标题显示为具体 SubAgent 名称，事件中的真实工具名保持不变。
+
+## 验收场景
+
+Given Claude 输出非流式 `assistant.tool_use(name=Read, input={file_path: ...})`，随后输出 `user.tool_result`
+
+When adapter 处于 streaming 模式
+
+Then stream 按顺序得到同一 ToolCallID 的 start、end、result；start 带 `Name=Read` 与完整 Args。
+
+Given 同一 ToolCallID 已通过 `stream_event` 输出 start、args、end
+
+When terminal assistant message再次携带该 tool_use
+
+Then fallback 不重复输出 start 或 end，原有 args 和 result 语义不变。
+
+Given 下游转发上述 payload 并由前端重放
+
+When 渲染 Explore 或其他非流式 Claude 工具调用卡片
+
+Then 卡片无需结果反推，直接展示名称、入参和结果。
+
+对应 adapter 测试：`claude/streaming_parser_test.go`。下游 FlowX 升级后应补充自身的转发和回放验收。
+
+## 变更边界
+
+允许修改：
+
+- `agent-adaptor/claude/parser.go`、`streaming_parser.go` 和测试
+- `agent-adaptor/pkg/bridges/agui/bridge.go` 和测试
+- `flowx-agent/cmd/flowx-agent/web/app.js` 和 `viewer_test.go`
+- `go.mod`、`go.sum`（仅版本发布所需变更）
+- 本 Plan
+
+禁止修改：
+
+- 外部前端的结果反推、cursor 兼容逻辑
+- Claude CLI 子 agent transcript 文件 tail
+- checkpoint、artifact、HITL 和 Team Mode 状态机
+- Rainbow、部署配置和业务运行时下发字段
+
+## 实施步骤
+
+- [x] 在 Claude streaming state 中实现非流式 tool_use 的 lifecycle fallback 与去重状态
+- [x] 在 parser 中接入 fallback
+- [x] 增加 Explore result-only fixture 与正常流式去重 fixture
+- [x] 增加 MCP 参数增量 fixture
+- [x] 增加 AG-UI 完整 Args 降级与去重测试
+- [x] 更新 FlowX Viewer 的参数聚合与 SubAgent 标题
+- [ ] 发布 adapter 修复版本
+- [ ] 向下游说明升级版本与验收条件
+- [x] 运行 Claude adapter、AG-UI bridge、FlowX 全仓测试和定向 race 测试
+- [x] 自检 Plan 与实现一致
+
+## 风险与回滚
+
+- Claude CLI 可能在不同版本中同时输出流式与非流式 tool_use；必须按 ToolCallID 去重。
+- fallback Args 来自完整 input，不生成伪造的增量 args 事件。
+- 可通过回退 `agent-adaptor` 版本恢复当前只显示结果的行为。

--- a/pkg/bridges/agui/bridge.go
+++ b/pkg/bridges/agui/bridge.go
@@ -77,6 +77,7 @@ type Translator struct {
 	activeText      map[string]bool
 	activeReason    map[string]bool
 	activeToolStart map[string]bool
+	toolStartArgs   map[string]string
 
 	// decisionMode selects HITL event translation. Default: DecisionAsToolCall.
 	decisionMode DecisionMode
@@ -89,6 +90,7 @@ func NewTranslator(opts ...TranslatorOption) *Translator {
 		activeText:      map[string]bool{},
 		activeReason:    map[string]bool{},
 		activeToolStart: map[string]bool{},
+		toolStartArgs:   map[string]string{},
 		decisionMode:    DecisionAsToolCall,
 	}
 	for _, o := range opts {
@@ -311,6 +313,11 @@ func (t *Translator) translateNonTerminalLocked(p agentadaptor.StreamPayload) []
 			return nil
 		}
 		t.activeToolStart[p.ToolCallID] = true
+		if len(p.Args) > 0 {
+			if raw, err := json.Marshal(p.Args); err == nil {
+				t.toolStartArgs[p.ToolCallID] = string(raw)
+			}
+		}
 		return []aguievents.Event{aguievents.NewToolCallStartEvent(p.ToolCallID, defaultString(p.Name, "tool"))}
 
 	case agentadaptor.StreamToolCallArgs:
@@ -325,6 +332,10 @@ func (t *Translator) translateNonTerminalLocked(p agentadaptor.StreamPayload) []
 			t.activeToolStart[p.ToolCallID] = true
 			out = append(out, aguievents.NewToolCallStartEvent(p.ToolCallID, defaultString(p.Name, "tool")))
 		}
+		// StreamToolCallArgs also carries command output for adapters such as
+		// Codex. Preserve that existing delta stream and suppress the complete
+		// start snapshot; concatenating both would produce invalid AG-UI args.
+		delete(t.toolStartArgs, p.ToolCallID)
 		out = append(out, aguievents.NewToolCallArgsEvent(p.ToolCallID, p.Delta))
 		return out
 
@@ -333,10 +344,17 @@ func (t *Translator) translateNonTerminalLocked(p agentadaptor.StreamPayload) []
 			return nil
 		}
 		if !t.activeToolStart[p.ToolCallID] {
+			delete(t.toolStartArgs, p.ToolCallID)
 			return nil
 		}
 		delete(t.activeToolStart, p.ToolCallID)
-		return []aguievents.Event{aguievents.NewToolCallEndEvent(p.ToolCallID)}
+		out := []aguievents.Event{}
+		if args := t.toolStartArgs[p.ToolCallID]; args != "" {
+			out = append(out, aguievents.NewToolCallArgsEvent(p.ToolCallID, args))
+		}
+		delete(t.toolStartArgs, p.ToolCallID)
+		out = append(out, aguievents.NewToolCallEndEvent(p.ToolCallID))
+		return out
 
 	case agentadaptor.StreamToolCallResult:
 		if p.ToolCallID == "" {
@@ -407,9 +425,13 @@ func (t *Translator) closeAllOpenLifecyclesLocked() []aguievents.Event {
 	}
 	t.activeReason = map[string]bool{}
 	for id := range t.activeToolStart {
+		if args := t.toolStartArgs[id]; args != "" {
+			out = append(out, aguievents.NewToolCallArgsEvent(id, args))
+		}
 		out = append(out, aguievents.NewToolCallEndEvent(id))
 	}
 	t.activeToolStart = map[string]bool{}
+	t.toolStartArgs = map[string]string{}
 	return out
 }
 

--- a/pkg/bridges/agui/bridge_test.go
+++ b/pkg/bridges/agui/bridge_test.go
@@ -2,6 +2,8 @@ package agui_test
 
 import (
 	"context"
+	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -119,6 +121,86 @@ func TestTranslatorToolCallLifecycle(t *testing.T) {
 		aguievents.EventTypeRunFinished,
 	}
 	assertTypesEqual(t, want, typesOf(events))
+	assertVerified(t, events)
+}
+
+func TestTranslatorToolCallStartArgsFallback(t *testing.T) {
+	t.Parallel()
+	tr := agui.NewTranslator()
+	events := translateAll(tr, []agentadaptor.StreamPayload{
+		{Kind: agentadaptor.StreamRunStarted, ThreadID: "t", RunID: "r"},
+		{Kind: agentadaptor.StreamToolCallStart, ToolCallID: "tc-snapshot", Name: "Read", Args: map[string]any{"file_path": "/tmp/x"}},
+		{Kind: agentadaptor.StreamToolCallEnd, ToolCallID: "tc-snapshot"},
+		{Kind: agentadaptor.StreamRunFinished, ThreadID: "t", RunID: "r"},
+	})
+	want := []aguievents.EventType{
+		aguievents.EventTypeRunStarted,
+		aguievents.EventTypeToolCallStart,
+		aguievents.EventTypeToolCallArgs,
+		aguievents.EventTypeToolCallEnd,
+		aguievents.EventTypeRunFinished,
+	}
+	assertTypesEqual(t, want, typesOf(events))
+	for _, event := range events {
+		args, ok := event.(*aguievents.ToolCallArgsEvent)
+		if !ok {
+			continue
+		}
+		var got map[string]any
+		if err := json.Unmarshal([]byte(args.Delta), &got); err != nil {
+			t.Fatalf("decode fallback args: %v", err)
+		}
+		if !reflect.DeepEqual(got, map[string]any{"file_path": "/tmp/x"}) {
+			t.Fatalf("fallback args: %#v", got)
+		}
+	}
+	assertVerified(t, events)
+}
+
+func TestTranslatorToolCallStartArgsFallbackOnRunFinish(t *testing.T) {
+	t.Parallel()
+	tr := agui.NewTranslator()
+	events := translateAll(tr, []agentadaptor.StreamPayload{
+		{Kind: agentadaptor.StreamRunStarted, ThreadID: "t", RunID: "r"},
+		{Kind: agentadaptor.StreamToolCallStart, ToolCallID: "tc-snapshot", Name: "Read", Args: map[string]any{"file_path": "/tmp/x"}},
+		{Kind: agentadaptor.StreamRunFinished, ThreadID: "t", RunID: "r"},
+	})
+	want := []aguievents.EventType{
+		aguievents.EventTypeRunStarted,
+		aguievents.EventTypeToolCallStart,
+		aguievents.EventTypeToolCallArgs,
+		aguievents.EventTypeToolCallEnd,
+		aguievents.EventTypeRunFinished,
+	}
+	assertTypesEqual(t, want, typesOf(events))
+	assertVerified(t, events)
+}
+
+func TestTranslatorToolCallStartArgsDoNotDuplicateStreamedDeltas(t *testing.T) {
+	t.Parallel()
+	tr := agui.NewTranslator()
+	events := translateAll(tr, []agentadaptor.StreamPayload{
+		{Kind: agentadaptor.StreamRunStarted, ThreadID: "t", RunID: "r"},
+		{Kind: agentadaptor.StreamToolCallStart, ToolCallID: "tc-stream", Name: "shell", Args: map[string]any{"command": "pwd"}},
+		{Kind: agentadaptor.StreamToolCallArgs, ToolCallID: "tc-stream", Delta: "/tmp/x\n"},
+		{Kind: agentadaptor.StreamToolCallEnd, ToolCallID: "tc-stream"},
+		{Kind: agentadaptor.StreamRunFinished, ThreadID: "t", RunID: "r"},
+	})
+
+	argsEvents := 0
+	for _, event := range events {
+		args, ok := event.(*aguievents.ToolCallArgsEvent)
+		if !ok {
+			continue
+		}
+		argsEvents++
+		if args.Delta != "/tmp/x\n" {
+			t.Fatalf("streamed delta: got %q", args.Delta)
+		}
+	}
+	if argsEvents != 1 {
+		t.Fatalf("expected one streamed args event, got %d", argsEvents)
+	}
 	assertVerified(t, events)
 }
 


### PR DESCRIPTION
## 状态

WIP，先保存当前实现，后续继续完善并补充真实 Viewer 回放验证。

## 修改内容

- 补齐 Claude 完整 `assistant.tool_use` 的 `start -> end -> result` 生命周期，并按 `ToolCallID` 去重
- 为 MCP 参数增量补充工具名，完整参数快照保持原始结构
- AG-UI 在只有 `start.Args` 时补发 `TOOL_CALL_ARGS`，同时避免与既有 delta 重复
- 增加 MCP、非流式工具调用和 AG-UI 降级场景测试

## 验证

- `go test ./...`
- `go test -race ./claude ./pkg/bridges/agui`
- `git diff --check`

## 后续

- 发布新的 `agent-adaptor` 版本并在 FlowX 更新依赖
- 提交 FlowX Viewer 的参数聚合与 SubAgent 标题展示改动
- 补充 Viewer 真实行为测试，并评估 thread tab 切换时的流式聚合状态恢复