### PR TITLE
通过 A2A 回传正文和工具执行过程

### DIFF
--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -222,11 +222,13 @@ a final `subagent.artifact.created` event and is never interpreted as text,
 reasoning, or a tool lifecycle. Hosts using `adapter.stream.v1` receive typed
 `DelegationEvent` values for each supported Status DataPart. A host-owned schema
 can implement `StatusPartDecoder` and pass it through `WithStatusPartDecoder`;
-the mapper locks one stream profile per delegation, deduplicates replayed status
-data, and reports sequence gaps as `subagent.stream.dropped`. For typed tool
-events, `StreamPayload.ToolCallID` is the remote tool-call ID; the parent model
-tool-call ID remains available as `parentToolCallId` and
-`Raw["parent_tool_call_id"]`.
+the decoder directly returns `DelegationEvent` values containing only its event
+meaning, while the mapper fills delegation identity, remote A2A context, profile,
+and default time. The mapper locks one stream profile per delegation,
+deduplicates replayed status data, and reports sequence gaps as
+`subagent.stream.dropped`. For typed tool events, `StreamPayload.ToolCallID` is
+the remote tool-call ID; the parent model tool-call ID remains available as
+`parentToolCallId` and `Raw["parent_tool_call_id"]`.
 
 `parentToolCallId` is included only when the host can supply the parent provider
 tool-call ID, for example by setting `a2adelegation.MCPServerOptions.ParentToolCallID`

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -27,7 +27,9 @@ The bridge maps A2A task execution onto the single SDK execution path:
 4. The bridge calls `Runner.Start(...)` and applies `RunStreaming` as the final
    per-call streaming override (`WithStreaming` by default,
    `WithoutStreaming` when disabled).
-5. `StreamEvents`, `Wait`, and `Cancel` are translated to A2A status, artifact, and terminal events. `ServerOptions.StreamWire` controls the intermediate-event wire profile.
+5. `StreamEvents` are translated to `TaskStatusUpdateEvent` DataParts using the
+   `adapter.stream.v1` schema. `Wait` and `Cancel` produce terminal status and
+   final artifact events.
 
 Bridge capability advertisement is strict:
 
@@ -39,16 +41,12 @@ Bridge capability advertisement is strict:
   compatibility, with `PromptBuilder` taking precedence when both are set.
 - `ServerOptions.ResultBuilder` can add or replace terminal artifacts and
   override completed status text. It runs only after a successful SDK result;
-  streamed artifacts already emitted during the run are not retroactively
-  removed.
-- `ServerOptions.StreamWire` defaults to `StreamWireLegacyArtifact`. Hosts that
-  set `StreamWireStatusData` send intermediate text, reasoning, tool, HITL, and
-  dropped-stream events as `TaskStatusUpdateEvent` DataParts using the stable
-  `adapter.stream.v1` schema. The server advertises the optional
-  `urn:agent-adaptor:stream:v1` Agent Card extension while each DataPart remains
-  self-describing, so existing clients do not need an extension negotiation
-  header. Terminal result artifacts
-  remain unchanged.
+  intermediate status events are not changed retroactively.
+- Intermediate text, reasoning, tool, HITL, and dropped-stream events always
+  use `TaskStatusUpdateEvent` DataParts with the stable `adapter.stream.v1`
+  schema. The server advertises the `urn:agent-adaptor:stream:v1` Agent Card
+  extension while each DataPart remains self-describing. `ArtifactUpdate` is
+  reserved for final result artifacts.
 
 ```go
 runner := sdk.Default()
@@ -67,7 +65,6 @@ server := a2a.NewServer(runner, a2a.ServerOptions{
 		}},
 	},
 	Session: a2a.SessionByContextID("a2a"),
-	StreamWire: a2a.StreamWireStatusData,
 	TaskLifecycle: a2a.TaskLifecycleOptions{
 		Ephemeral: &a2a.EphemeralTaskStoreOptions{
 			MaxTasks: 512,
@@ -83,7 +80,7 @@ mux.Handle("/a2a", server.Handler())
 
 See [`examples/a2a-local`](../examples/a2a-local) for a runnable local
 end-to-end demo that starts this bridge around a real local SDK runner, calls
-it with `pkg/clients/a2a`, consumes streaming artifacts, and verifies the final
+it with `pkg/clients/a2a`, consumes streaming status updates, and verifies the final
 task with `GetTask`. The example defaults to an isolated temporary workspace
 and isolated cloned provider profile seeded from native settings so custom API
 key / base URL setups work without writing demo state into a host's active
@@ -91,14 +88,9 @@ local agent profile.
 
 The terminal result is emitted as a structured artifact named `agent-adaptor-result`. Assistant-facing output remains in the final A2A status message. The default artifact contains only the safe summary; diagnostics such as metadata, usage, provider result payloads, transcript, raw streams, reasoning, tool-call internals, and HITL payloads require explicit `ExposurePolicy` opt-in and are sanitized before they cross the A2A boundary.
 
-In the default legacy wire mode, bridge-owned artifact names are part of the
-package contract for hosts that compose this bridge with higher-level stream overlays:
-
-- `a2a.ArtifactAssistantOutput` (`assistant-output`) carries streamed
-  assistant-facing text deltas and closes with `lastChunk=true`.
-- `a2a.ArtifactAgentAdaptorResult` (`agent-adaptor-result`) carries the
-  terminal summary and any opt-in sanitized diagnostics, and is emitted as a
-  single final chunk.
+`a2a.ArtifactAgentAdaptorResult` (`agent-adaptor-result`) carries the terminal
+summary and any opt-in sanitized diagnostics, and is emitted as a single final
+chunk. No bridge-owned artifact name represents an intermediate process event.
 
 Task retention is explicit. `NewServer` no longer hides the upstream unbounded in-memory task store. If `ServerOptions.TaskLifecycle.Store` is nil, the bridge uses a bounded ephemeral store with a default `MaxTasks=256` and `TTL=1h`. Hosts that need durable retention, custom paging/auth behavior, or cross-process lifecycle ownership must inject their own `a2asrv/taskstore.Store`.
 
@@ -224,18 +216,17 @@ progress is published to the bus and rendered as AG-UI custom events:
 ```
 
 Assistant output uses the ordered `subagent.text.start`,
-`subagent.text.delta`, and `subagent.text.end` lifecycle. The mapper accepts both
-legacy bridge artifacts and StatusUpdate DataParts. Hosts using
-`adapter.stream.v1` receive typed `DelegationEvent` values for each supported
-Status DataPart. A host-owned schema can implement `StatusPartDecoder` and pass
-it through `WithStatusPartDecoder`; the mapper locks one stream profile per
-delegation, deduplicates replayed status data, and reports sequence gaps as
-`subagent.stream.dropped`. Legacy tool artifacts continue to emit typed
-`subagent.tool_call.start`, `subagent.tool_call.args`,
-`subagent.tool_call.result`, and `subagent.tool_call.end` events during rolling
-upgrades. For typed tool events, `StreamPayload.ToolCallID` is the remote
-tool-call ID; the parent model tool-call ID remains available as
-`parentToolCallId` and `Raw["parent_tool_call_id"]`.
+`subagent.text.delta`, and `subagent.text.end` lifecycle. Process events are
+decoded only from StatusUpdate message parts. `ArtifactUpdate` always produces
+a final `subagent.artifact.created` event and is never interpreted as text,
+reasoning, or a tool lifecycle. Hosts using `adapter.stream.v1` receive typed
+`DelegationEvent` values for each supported Status DataPart. A host-owned schema
+can implement `StatusPartDecoder` and pass it through `WithStatusPartDecoder`;
+the mapper locks one stream profile per delegation, deduplicates replayed status
+data, and reports sequence gaps as `subagent.stream.dropped`. For typed tool
+events, `StreamPayload.ToolCallID` is the remote tool-call ID; the parent model
+tool-call ID remains available as `parentToolCallId` and
+`Raw["parent_tool_call_id"]`.
 
 `parentToolCallId` is included only when the host can supply the parent provider
 tool-call ID, for example by setting `a2adelegation.MCPServerOptions.ParentToolCallID`

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -27,7 +27,7 @@ The bridge maps A2A task execution onto the single SDK execution path:
 4. The bridge calls `Runner.Start(...)` and applies `RunStreaming` as the final
    per-call streaming override (`WithStreaming` by default,
    `WithoutStreaming` when disabled).
-5. `StreamEvents`, `Wait`, and `Cancel` are translated to A2A status, artifact, and terminal events.
+5. `StreamEvents`, `Wait`, and `Cancel` are translated to A2A status, artifact, and terminal events. `ServerOptions.StreamWire` controls the intermediate-event wire profile.
 
 Bridge capability advertisement is strict:
 
@@ -41,6 +41,14 @@ Bridge capability advertisement is strict:
   override completed status text. It runs only after a successful SDK result;
   streamed artifacts already emitted during the run are not retroactively
   removed.
+- `ServerOptions.StreamWire` defaults to `StreamWireLegacyArtifact`. Hosts that
+  set `StreamWireStatusData` send intermediate text, reasoning, tool, HITL, and
+  dropped-stream events as `TaskStatusUpdateEvent` DataParts using the stable
+  `adapter.stream.v1` schema. The server advertises the optional
+  `urn:agent-adaptor:stream:v1` Agent Card extension while each DataPart remains
+  self-describing, so existing clients do not need an extension negotiation
+  header. Terminal result artifacts
+  remain unchanged.
 
 ```go
 runner := sdk.Default()
@@ -59,6 +67,7 @@ server := a2a.NewServer(runner, a2a.ServerOptions{
 		}},
 	},
 	Session: a2a.SessionByContextID("a2a"),
+	StreamWire: a2a.StreamWireStatusData,
 	TaskLifecycle: a2a.TaskLifecycleOptions{
 		Ephemeral: &a2a.EphemeralTaskStoreOptions{
 			MaxTasks: 512,
@@ -82,8 +91,8 @@ local agent profile.
 
 The terminal result is emitted as a structured artifact named `agent-adaptor-result`. Assistant-facing output remains in the final A2A status message. The default artifact contains only the safe summary; diagnostics such as metadata, usage, provider result payloads, transcript, raw streams, reasoning, tool-call internals, and HITL payloads require explicit `ExposurePolicy` opt-in and are sanitized before they cross the A2A boundary.
 
-Bridge-owned artifact names are part of the package contract for hosts that
-compose this bridge with higher-level stream overlays:
+In the default legacy wire mode, bridge-owned artifact names are part of the
+package contract for hosts that compose this bridge with higher-level stream overlays:
 
 - `a2a.ArtifactAssistantOutput` (`assistant-output`) carries streamed
   assistant-facing text deltas and closes with `lastChunk=true`.
@@ -215,13 +224,18 @@ progress is published to the bus and rendered as AG-UI custom events:
 ```
 
 Assistant output uses the ordered `subagent.text.start`,
-`subagent.text.delta`, and `subagent.text.end` lifecycle. Bridge-generated tool
-artifacts continue to emit `subagent.artifact` for existing consumers and also
-emit typed `subagent.tool_call.start`, `subagent.tool_call.args`,
-`subagent.tool_call.result`, and `subagent.tool_call.end` events. For typed tool
-events, `StreamPayload.ToolCallID` is the remote tool-call ID; the parent model
-tool-call ID remains available as `parentToolCallId` and
-`Raw["parent_tool_call_id"]`.
+`subagent.text.delta`, and `subagent.text.end` lifecycle. The mapper accepts both
+legacy bridge artifacts and StatusUpdate DataParts. Hosts using
+`adapter.stream.v1` receive typed `DelegationEvent` values for each supported
+Status DataPart. A host-owned schema can implement `StatusPartDecoder` and pass
+it through `WithStatusPartDecoder`; the mapper locks one stream profile per
+delegation, deduplicates replayed status data, and reports sequence gaps as
+`subagent.stream.dropped`. Legacy tool artifacts continue to emit typed
+`subagent.tool_call.start`, `subagent.tool_call.args`,
+`subagent.tool_call.result`, and `subagent.tool_call.end` events during rolling
+upgrades. For typed tool events, `StreamPayload.ToolCallID` is the remote
+tool-call ID; the parent model tool-call ID remains available as
+`parentToolCallId` and `Raw["parent_tool_call_id"]`.
 
 `parentToolCallId` is included only when the host can supply the parent provider
 tool-call ID, for example by setting `a2adelegation.MCPServerOptions.ParentToolCallID`

--- a/examples/a2a-local/main.go
+++ b/examples/a2a-local/main.go
@@ -399,18 +399,24 @@ func consumeStream(stream *clienta2a.Stream) (streamSummary, string, error) {
 		case clienta2a.EventStatus:
 			if event.Status != nil {
 				rememberState(&summary, event.Status.State)
+				if event.Status.Message != nil {
+					for _, part := range event.Status.Message.Parts {
+						if part.Kind != clienta2a.PartData {
+							continue
+						}
+						payload, matched, err := bridgea2a.DecodeAdapterStreamStatus(part.Data)
+						if err == nil && matched && payload.Kind == agentadaptor.StreamTextContent {
+							output.WriteString(payload.Delta)
+						}
+					}
+				}
 			}
 		case clienta2a.EventArtifact:
 			summary.ArtifactChunks++
 			if event.Artifact == nil {
 				continue
 			}
-			switch event.Artifact.Name {
-			case bridgea2a.ArtifactAssistantOutput:
-				if !event.LastChunk {
-					output.WriteString(partsText(event.Artifact.Parts))
-				}
-			case bridgea2a.ArtifactAgentAdaptorResult:
+			if event.Artifact.Name == bridgea2a.ArtifactAgentAdaptorResult {
 				summary.ResultArtifactSeen = true
 			}
 		case clienta2a.EventTerminal:

--- a/pkg/bridges/a2a/convert_internal_test.go
+++ b/pkg/bridges/a2a/convert_internal_test.go
@@ -85,7 +85,7 @@ func TestOutboundPartsTreatsZeroKindAsText(t *testing.T) {
 
 func TestCustomTerminalArtifactsRejectReservedAndDuplicateIDs(t *testing.T) {
 	part := []Part{{Kind: PartText, Text: "result"}}
-	if _, err := customTerminalArtifacts(testTaskInfo{}, []ArtifactSpec{{ID: ArtifactAssistantOutput, Parts: part}}, map[string]struct{}{ArtifactAssistantOutput: {}}); err == nil {
+	if _, err := customTerminalArtifacts(testTaskInfo{}, []ArtifactSpec{{ID: ArtifactAgentAdaptorResult, Parts: part}}, reservedArtifactIDs(false)); err == nil {
 		t.Fatal("expected reserved artifact ID to fail")
 	}
 	if _, err := customTerminalArtifacts(testTaskInfo{}, []ArtifactSpec{{ID: "result", Parts: part}, {ID: "result", Parts: part}}, nil); err == nil {
@@ -103,18 +103,22 @@ func TestStreamTranslatorEmitsToolEndWithoutArgs(t *testing.T) {
 	if len(end) != 1 {
 		t.Fatalf("end = %#v", end)
 	}
-	update, ok := end[0].(*a2aproto.TaskArtifactUpdateEvent)
-	if !ok || len(update.Artifact.Parts) != 1 {
+	update, ok := end[0].(*a2aproto.TaskStatusUpdateEvent)
+	if !ok || update.Status.Message == nil || len(update.Status.Message.Parts) != 1 {
 		t.Fatalf("end event = %#v", end[0])
 	}
-	data, ok := update.Artifact.Parts[0].Content.(a2aproto.Data)
-	if !ok || data.Value.(map[string]any)["kind"] != "tool_call.end" {
-		t.Fatalf("end data = %#v", update.Artifact.Parts[0].Content)
+	data, ok := update.Status.Message.Parts[0].Content.(a2aproto.Data)
+	if !ok {
+		t.Fatalf("end data = %#v", update.Status.Message.Parts[0].Content)
+	}
+	payload, matched, err := DecodeAdapterStreamStatus(data.Value)
+	if err != nil || !matched || payload.Kind != agentadaptor.StreamToolCallEnd {
+		t.Fatalf("end payload=%#v matched=%v err=%v", payload, matched, err)
 	}
 }
 
 func TestStreamTranslatorStatusDataRoundTrip(t *testing.T) {
-	translator := newStreamTranslator(testTaskInfo{}, ExposurePolicy{IncludeToolCalls: true}, StreamWireStatusData)
+	translator := newStreamTranslator(testTaskInfo{}, ExposurePolicy{IncludeToolCalls: true})
 	want := []agentadaptor.StreamPayload{
 		{Kind: agentadaptor.StreamTextStart, Sequence: 1, MessageID: "msg-1"},
 		{Kind: agentadaptor.StreamTextContent, Sequence: 2, MessageID: "msg-1", Delta: "hello"},
@@ -163,7 +167,7 @@ func TestDecodeAdapterStreamStatusIgnoresOtherSchemas(t *testing.T) {
 }
 
 func TestStreamTranslatorStatusDataReportsOversizedEvent(t *testing.T) {
-	translator := newStreamTranslator(testTaskInfo{}, ExposurePolicy{}, StreamWireStatusData)
+	translator := newStreamTranslator(testTaskInfo{}, ExposurePolicy{})
 	events := translator.Translate(agentadaptor.StreamPayload{
 		Kind: agentadaptor.StreamTextContent, Sequence: 9, MessageID: "msg-1",
 		Delta: strings.Repeat("x", adapterStreamMaxBytes),

--- a/pkg/bridges/a2a/convert_internal_test.go
+++ b/pkg/bridges/a2a/convert_internal_test.go
@@ -3,6 +3,7 @@ package a2a
 import (
 	"encoding/json"
 	"math"
+	"strings"
 	"testing"
 
 	a2aproto "github.com/a2aproject/a2a-go/v2/a2a"
@@ -109,5 +110,74 @@ func TestStreamTranslatorEmitsToolEndWithoutArgs(t *testing.T) {
 	data, ok := update.Artifact.Parts[0].Content.(a2aproto.Data)
 	if !ok || data.Value.(map[string]any)["kind"] != "tool_call.end" {
 		t.Fatalf("end data = %#v", update.Artifact.Parts[0].Content)
+	}
+}
+
+func TestStreamTranslatorStatusDataRoundTrip(t *testing.T) {
+	translator := newStreamTranslator(testTaskInfo{}, ExposurePolicy{IncludeToolCalls: true}, StreamWireStatusData)
+	want := []agentadaptor.StreamPayload{
+		{Kind: agentadaptor.StreamTextStart, Sequence: 1, MessageID: "msg-1"},
+		{Kind: agentadaptor.StreamTextContent, Sequence: 2, MessageID: "msg-1", Delta: "hello"},
+		{Kind: agentadaptor.StreamTextEnd, Sequence: 3, MessageID: "msg-1"},
+		{Kind: agentadaptor.StreamToolCallStart, Sequence: 4, ToolCallID: "tool-1", Name: "Bash"},
+		{Kind: agentadaptor.StreamToolCallArgs, Sequence: 5, ToolCallID: "tool-1", Delta: `{"command":`},
+		{Kind: agentadaptor.StreamToolCallEnd, Sequence: 6, ToolCallID: "tool-1"},
+		{Kind: agentadaptor.StreamToolCallResult, Sequence: 7, ToolCallID: "tool-1", Result: map[string]any{"exit_code": 0}},
+	}
+	for _, payload := range want {
+		events := translator.Translate(payload)
+		if len(events) != 1 {
+			t.Fatalf("%s events = %#v", payload.Kind, events)
+		}
+		update, ok := events[0].(*a2aproto.TaskStatusUpdateEvent)
+		if !ok || update.Status.State != a2aproto.TaskStateWorking || update.Status.Message == nil || len(update.Status.Message.Parts) != 1 {
+			t.Fatalf("%s status event = %#v", payload.Kind, events[0])
+		}
+		data, ok := update.Status.Message.Parts[0].Content.(a2aproto.Data)
+		if !ok {
+			t.Fatalf("%s data part = %#v", payload.Kind, update.Status.Message.Parts[0])
+		}
+		got, matched, err := DecodeAdapterStreamStatus(data.Value)
+		if err != nil || !matched {
+			t.Fatalf("%s decode matched=%v err=%v", payload.Kind, matched, err)
+		}
+		if got.Kind != payload.Kind || got.Sequence != payload.Sequence || got.MessageID != payload.MessageID ||
+			got.ToolCallID != payload.ToolCallID || got.Name != payload.Name || got.Delta != payload.Delta {
+			t.Fatalf("%s round trip = %#v, want %#v", payload.Kind, got, payload)
+		}
+	}
+}
+
+func TestDecodeAdapterStreamStatusIgnoresOtherSchemas(t *testing.T) {
+	_, matched, err := DecodeAdapterStreamStatus(map[string]any{"type": "STATUS_TYPE_TOOL_CALL"})
+	if err != nil || matched {
+		t.Fatalf("matched=%v err=%v", matched, err)
+	}
+	_, matched, err = DecodeAdapterStreamStatus(map[string]any{
+		"schema":  "external.status.v1",
+		"payload": strings.Repeat("x", adapterStreamMaxBytes),
+	})
+	if err != nil || matched {
+		t.Fatalf("oversized external schema matched=%v err=%v", matched, err)
+	}
+}
+
+func TestStreamTranslatorStatusDataReportsOversizedEvent(t *testing.T) {
+	translator := newStreamTranslator(testTaskInfo{}, ExposurePolicy{}, StreamWireStatusData)
+	events := translator.Translate(agentadaptor.StreamPayload{
+		Kind: agentadaptor.StreamTextContent, Sequence: 9, MessageID: "msg-1",
+		Delta: strings.Repeat("x", adapterStreamMaxBytes),
+	})
+	if len(events) != 1 {
+		t.Fatalf("events = %#v", events)
+	}
+	update := events[0].(*a2aproto.TaskStatusUpdateEvent)
+	data := update.Status.Message.Parts[0].Content.(a2aproto.Data)
+	payload, matched, err := DecodeAdapterStreamStatus(data.Value)
+	if err != nil || !matched || payload.Kind != agentadaptor.StreamDropped || payload.Sequence != 9 {
+		t.Fatalf("overflow payload=%#v matched=%v err=%v", payload, matched, err)
+	}
+	if payload.Raw["dropped_kind"] != string(agentadaptor.StreamTextContent) {
+		t.Fatalf("overflow raw = %#v", payload.Raw)
 	}
 }

--- a/pkg/bridges/a2a/mapping.go
+++ b/pkg/bridges/a2a/mapping.go
@@ -13,16 +13,28 @@ import (
 type streamTranslator struct {
 	info     a2aproto.TaskInfoProvider
 	exposure ExposurePolicy
+	wireMode StreamWireMode
 	started  map[a2aproto.ArtifactID]bool
 }
 
-func newStreamTranslator(info a2aproto.TaskInfoProvider, exposure ExposurePolicy) *streamTranslator {
+func newStreamTranslator(info a2aproto.TaskInfoProvider, exposure ExposurePolicy, wireMode ...StreamWireMode) *streamTranslator {
+	mode := StreamWireLegacyArtifact
+	if len(wireMode) > 0 {
+		mode = wireMode[0]
+	}
 	return &streamTranslator{
-		info: info, exposure: exposure, started: map[a2aproto.ArtifactID]bool{},
+		info: info, exposure: exposure, wireMode: mode, started: map[a2aproto.ArtifactID]bool{},
 	}
 }
 
 func (t *streamTranslator) Translate(p agentadaptor.StreamPayload) []a2aproto.Event {
+	if t.wireMode == StreamWireStatusData {
+		return t.translateStatusData(p)
+	}
+	return t.translateLegacyArtifact(p)
+}
+
+func (t *streamTranslator) translateLegacyArtifact(p agentadaptor.StreamPayload) []a2aproto.Event {
 	switch p.Kind {
 	case agentadaptor.StreamTextContent:
 		if p.Delta == "" {
@@ -107,6 +119,62 @@ func (t *streamTranslator) Translate(p agentadaptor.StreamPayload) []a2aproto.Ev
 		return []a2aproto.Event{t.dataArtifact("stream-dropped", "stream-dropped", data, true)}
 	default:
 		return nil
+	}
+}
+
+func (t *streamTranslator) translateStatusData(p agentadaptor.StreamPayload) []a2aproto.Event {
+	switch p.Kind {
+	case agentadaptor.StreamTextStart, agentadaptor.StreamTextContent, agentadaptor.StreamTextEnd:
+	case agentadaptor.StreamToolCallStart, agentadaptor.StreamToolCallArgs,
+		agentadaptor.StreamToolCallEnd, agentadaptor.StreamToolCallResult:
+		if !t.exposure.IncludeToolCalls {
+			return nil
+		}
+	case agentadaptor.StreamReasoningStart, agentadaptor.StreamReasoningContent, agentadaptor.StreamReasoningEnd:
+		if !t.exposure.IncludeReasoning {
+			return nil
+		}
+	case agentadaptor.StreamHITLRequested, agentadaptor.StreamHITLResolved:
+		if !t.exposure.IncludeHITL {
+			return nil
+		}
+	case agentadaptor.StreamRunError:
+		msg := "stream run error"
+		if p.Error != nil && p.Error.Message != "" {
+			msg = p.Error.Message
+		}
+		return []a2aproto.Event{a2aproto.NewStatusUpdateEvent(t.info, a2aproto.TaskStateFailed, failureMessage(t.info, msg, streamFailureDetails(p.Error, t.exposure)))}
+	case agentadaptor.StreamDropped:
+		if !t.exposure.hasStreamingDiagnostics() {
+			return nil
+		}
+	default:
+		return nil
+	}
+	data, err := encodeAdapterStreamStatus(p, t.exposure)
+	if err != nil {
+		data = encodeAdapterStreamDrop(p, err)
+	}
+	msg := a2aproto.NewMessageForTask(a2aproto.MessageRoleAgent, t.info, dataPart(data))
+	return []a2aproto.Event{a2aproto.NewStatusUpdateEvent(t.info, a2aproto.TaskStateWorking, msg)}
+}
+
+func encodeAdapterStreamDrop(p agentadaptor.StreamPayload, cause error) map[string]any {
+	sequence := p.Sequence
+	if sequence == 0 {
+		sequence = p.Seq
+	}
+	return map[string]any{
+		"schema": AdapterStreamSchemaV1,
+		"event": map[string]any{
+			"kind":     string(agentadaptor.StreamDropped),
+			"sequence": sequence,
+			"raw": map[string]any{
+				"dropped_kind":  string(p.Kind),
+				"dropped_count": 1,
+				"reason":        cause.Error(),
+			},
+		},
 	}
 }
 

--- a/pkg/bridges/a2a/mapping.go
+++ b/pkg/bridges/a2a/mapping.go
@@ -2,7 +2,6 @@ package a2a
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	a2aproto "github.com/a2aproject/a2a-go/v2/a2a"
@@ -13,113 +12,14 @@ import (
 type streamTranslator struct {
 	info     a2aproto.TaskInfoProvider
 	exposure ExposurePolicy
-	wireMode StreamWireMode
-	started  map[a2aproto.ArtifactID]bool
 }
 
-func newStreamTranslator(info a2aproto.TaskInfoProvider, exposure ExposurePolicy, wireMode ...StreamWireMode) *streamTranslator {
-	mode := StreamWireLegacyArtifact
-	if len(wireMode) > 0 {
-		mode = wireMode[0]
-	}
-	return &streamTranslator{
-		info: info, exposure: exposure, wireMode: mode, started: map[a2aproto.ArtifactID]bool{},
-	}
+func newStreamTranslator(info a2aproto.TaskInfoProvider, exposure ExposurePolicy) *streamTranslator {
+	return &streamTranslator{info: info, exposure: exposure}
 }
 
 func (t *streamTranslator) Translate(p agentadaptor.StreamPayload) []a2aproto.Event {
-	if t.wireMode == StreamWireStatusData {
-		return t.translateStatusData(p)
-	}
-	return t.translateLegacyArtifact(p)
-}
-
-func (t *streamTranslator) translateLegacyArtifact(p agentadaptor.StreamPayload) []a2aproto.Event {
-	switch p.Kind {
-	case agentadaptor.StreamTextContent:
-		if p.Delta == "" {
-			return nil
-		}
-		return []a2aproto.Event{t.artifact(ArtifactAssistantOutput, ArtifactAssistantOutput, p.Delta, true)}
-	case agentadaptor.StreamTextEnd:
-		return t.closeArtifact(ArtifactAssistantOutput, ArtifactAssistantOutput)
-	case agentadaptor.StreamToolCallStart:
-		if !t.exposure.IncludeToolCalls {
-			return nil
-		}
-		data := map[string]any{"kind": "tool_call.start", "id": p.ToolCallID, "name": p.Name}
-		if len(p.Args) > 0 {
-			data["args"] = sanitizeRemoteValue(p.Args)
-		}
-		id := a2aproto.ArtifactID("tool-call-" + defaultString(p.ToolCallID, p.Name))
-		return []a2aproto.Event{t.dataArtifact(id, string(id), data, true)}
-	case agentadaptor.StreamToolCallArgs:
-		if !t.exposure.IncludeToolCalls || p.Delta == "" {
-			return nil
-		}
-		id := a2aproto.ArtifactID("tool-call-" + defaultString(p.ToolCallID, "args"))
-		return []a2aproto.Event{t.artifact(id, string(id), p.Delta, true)}
-	case agentadaptor.StreamToolCallEnd:
-		if !t.exposure.IncludeToolCalls {
-			return nil
-		}
-		toolID := defaultString(p.ToolCallID, "unknown")
-		argsID := a2aproto.ArtifactID("tool-call-" + defaultString(p.ToolCallID, "args"))
-		if t.started[argsID] {
-			return t.closeArtifact(argsID, string(argsID))
-		}
-		id := a2aproto.ArtifactID("tool-call-" + toolID + "-end")
-		return []a2aproto.Event{t.dataArtifact(id, string(id), map[string]any{
-			"kind": "tool_call.end", "id": p.ToolCallID,
-		}, true)}
-	case agentadaptor.StreamToolCallResult:
-		if !t.exposure.IncludeToolCalls {
-			return nil
-		}
-		id := a2aproto.ArtifactID("tool-call-" + defaultString(p.ToolCallID, "result"))
-		return []a2aproto.Event{t.dataArtifact(id, string(id), map[string]any{
-			"kind": "tool_call.result", "id": p.ToolCallID, "result": sanitizeRemoteValue(p.Result),
-		}, true)}
-	case agentadaptor.StreamReasoningContent:
-		if !t.exposure.IncludeReasoning || p.Delta == "" {
-			return nil
-		}
-		ev := t.artifact("reasoning", "reasoning", p.Delta, true)
-		ev.Artifact.Name = "reasoning"
-		return []a2aproto.Event{ev}
-	case agentadaptor.StreamReasoningEnd:
-		if !t.exposure.IncludeReasoning {
-			return nil
-		}
-		return t.closeArtifact("reasoning", "reasoning")
-	case agentadaptor.StreamHITLRequested:
-		if !t.exposure.IncludeHITL {
-			return nil
-		}
-		return []a2aproto.Event{t.dataArtifact("human-decision-request", "human-decision-request", hitlRequestedArtifact(p, t.exposure), true)}
-	case agentadaptor.StreamHITLResolved:
-		if !t.exposure.IncludeHITL {
-			return nil
-		}
-		return []a2aproto.Event{t.dataArtifact("human-decision-result", "human-decision-result", hitlResolvedArtifact(p, t.exposure), true)}
-	case agentadaptor.StreamRunError:
-		msg := "stream run error"
-		if p.Error != nil && p.Error.Message != "" {
-			msg = p.Error.Message
-		}
-		return []a2aproto.Event{a2aproto.NewStatusUpdateEvent(t.info, a2aproto.TaskStateFailed, failureMessage(t.info, msg, streamFailureDetails(p.Error, t.exposure)))}
-	case agentadaptor.StreamDropped:
-		if !t.exposure.hasStreamingDiagnostics() {
-			return nil
-		}
-		data := map[string]any{"kind": string(p.Kind)}
-		if dropped, ok := p.Raw["dropped_count"]; ok {
-			data["dropped_count"] = dropped
-		}
-		return []a2aproto.Event{t.dataArtifact("stream-dropped", "stream-dropped", data, true)}
-	default:
-		return nil
-	}
+	return t.translateStatusData(p)
 }
 
 func (t *streamTranslator) translateStatusData(p agentadaptor.StreamPayload) []a2aproto.Event {
@@ -178,72 +78,12 @@ func encodeAdapterStreamDrop(p agentadaptor.StreamPayload, cause error) map[stri
 	}
 }
 
-func (t *streamTranslator) artifact(id a2aproto.ArtifactID, name, text string, appendChunk bool) *a2aproto.TaskArtifactUpdateEvent {
-	var ev *a2aproto.TaskArtifactUpdateEvent
-	if t.started[id] {
-		ev = a2aproto.NewArtifactUpdateEvent(t.info, id, textPart(text))
-	} else {
-		ev = a2aproto.NewArtifactUpdateEvent(t.info, id, textPart(text))
-		ev.Append = false
-		t.started[id] = true
-	}
-	ev.Artifact.ID = id
-	ev.Artifact.Name = name
-	ev.Append = appendChunk && ev.Append
-	return ev
-}
-
-func (t *streamTranslator) closeArtifact(id a2aproto.ArtifactID, name string) []a2aproto.Event {
-	if !t.started[id] {
-		return nil
-	}
-	ev := a2aproto.NewArtifactUpdateEvent(t.info, id, textPart(""))
-	ev.Artifact.ID = id
-	ev.Artifact.Name = name
-	ev.LastChunk = true
-	t.started[id] = false
-	return []a2aproto.Event{ev}
-}
-
-func (t *streamTranslator) CloseOpen() []a2aproto.Event {
-	if len(t.started) == 0 {
-		return nil
-	}
-	ids := make([]string, 0, len(t.started))
-	for id, started := range t.started {
-		if started {
-			ids = append(ids, string(id))
-		}
-	}
-	sort.Strings(ids)
-	out := make([]a2aproto.Event, 0, len(ids))
-	for _, id := range ids {
-		out = append(out, t.closeArtifact(a2aproto.ArtifactID(id), id)...)
-	}
-	return out
-}
-
-func (t *streamTranslator) dataArtifact(id a2aproto.ArtifactID, name string, data map[string]any, lastChunk bool) *a2aproto.TaskArtifactUpdateEvent {
-	ev := a2aproto.NewArtifactUpdateEvent(t.info, id, dataPart(data))
-	if !t.started[id] {
-		ev.Append = false
-		t.started[id] = true
-	}
-	ev.Artifact.ID = id
-	ev.Artifact.Name = name
-	ev.LastChunk = lastChunk
-	if lastChunk {
-		t.started[id] = false
-	}
-	return ev
-}
-
 func terminalArtifacts(info a2aproto.TaskInfoProvider, result agentadaptor.RunResult, exposure ExposurePolicy, built BuiltResult) ([]a2aproto.Event, error) {
 	var out []a2aproto.Event
 	if !built.ReplaceDefaultArtifacts {
 		out = append(out, defaultTerminalArtifacts(info, result, exposure)...)
 	}
-	custom, err := customTerminalArtifacts(info, built.Artifacts, reservedArtifactIDs(exposure, built.ReplaceDefaultArtifacts))
+	custom, err := customTerminalArtifacts(info, built.Artifacts, reservedArtifactIDs(built.ReplaceDefaultArtifacts))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +136,7 @@ func customTerminalArtifacts(info a2aproto.TaskInfoProvider, artifacts []Artifac
 		if id == "" {
 			return nil, fmt.Errorf("custom artifact %d requires ID or Name", i)
 		}
-		if _, ok := reserved[id]; ok || strings.HasPrefix(id, "tool-call-") {
+		if _, ok := reserved[id]; ok {
 			return nil, fmt.Errorf("custom artifact id %q is reserved by the bridge", id)
 		}
 		if _, ok := seen[id]; ok {
@@ -324,20 +164,10 @@ func customTerminalArtifacts(info a2aproto.TaskInfoProvider, artifacts []Artifac
 	return out, nil
 }
 
-func reservedArtifactIDs(exposure ExposurePolicy, replaceDefault bool) map[string]struct{} {
-	reserved := map[string]struct{}{ArtifactAssistantOutput: {}}
+func reservedArtifactIDs(replaceDefault bool) map[string]struct{} {
+	reserved := map[string]struct{}{}
 	if !replaceDefault {
 		reserved[ArtifactAgentAdaptorResult] = struct{}{}
-	}
-	if exposure.IncludeReasoning {
-		reserved["reasoning"] = struct{}{}
-	}
-	if exposure.IncludeHITL {
-		reserved["human-decision-request"] = struct{}{}
-		reserved["human-decision-result"] = struct{}{}
-	}
-	if exposure.hasStreamingDiagnostics() {
-		reserved["stream-dropped"] = struct{}{}
 	}
 	return reserved
 }

--- a/pkg/bridges/a2a/server.go
+++ b/pkg/bridges/a2a/server.go
@@ -29,14 +29,12 @@ func NewServer(runner agentadaptor.Runner, opts ServerOptions) *Server {
 	if runner == nil {
 		panic("a2a bridge: nil runner")
 	}
-	if opts.StreamWire == StreamWireStatusData {
-		opts.AgentCard.Capabilities.Extensions = append(opts.AgentCard.Capabilities.Extensions, Extension{
-			URI:         AdapterStreamExtensionURI,
-			Description: "Streams agent-adaptor intermediate events through TaskStatusUpdateEvent DataParts.",
-			Required:    false,
-			Params:      map[string]any{"schema": AdapterStreamSchemaV1},
-		})
-	}
+	opts.AgentCard.Capabilities.Extensions = append(opts.AgentCard.Capabilities.Extensions, Extension{
+		URI:         AdapterStreamExtensionURI,
+		Description: "Streams agent-adaptor intermediate events through TaskStatusUpdateEvent DataParts.",
+		Required:    false,
+		Params:      map[string]any{"schema": AdapterStreamSchemaV1},
+	})
 	card, err := buildAgentCard(opts.AgentCard)
 	if err != nil {
 		panic(err)
@@ -60,7 +58,6 @@ func NewServer(runner agentadaptor.Runner, opts ServerOptions) *Server {
 		runner: runner, session: opts.Session, prompt: promptBuilder,
 		runOptions:    append([]agentadaptor.RunOption(nil), opts.RunOptions...),
 		runStreaming:  opts.RunStreaming,
-		streamWire:    opts.StreamWire,
 		resultBuilder: opts.ResultBuilder,
 		exposure:      opts.Exposure,
 		active:        map[a2aproto.TaskID]agentadaptor.RunHandle{},
@@ -102,7 +99,6 @@ type executor struct {
 	prompt        PromptBuilder
 	runOptions    []agentadaptor.RunOption
 	runStreaming  RunStreamingMode
-	streamWire    StreamWireMode
 	resultBuilder ResultBuilder
 	exposure      ExposurePolicy
 
@@ -182,7 +178,7 @@ func (e *executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext)
 		defer e.delete(execCtx.TaskID)
 
 		// 3. Forward stream payloads while Wait collects the terminal SDK result.
-		translator := newStreamTranslator(execCtx, e.exposure, e.streamWire)
+		translator := newStreamTranslator(execCtx, e.exposure)
 		waitCh := make(chan waitResult, 1)
 		go func() {
 			result, err := handle.Wait(runCtx)
@@ -209,13 +205,8 @@ func (e *executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext)
 		}
 
 	drained:
-		// 4. Close open stream artifacts, then project exactly one terminal outcome.
+		// 4. Project exactly one terminal outcome.
 		out := <-waitCh
-		for _, ev := range translator.CloseOpen() {
-			if !yield(ev, nil) {
-				return
-			}
-		}
 		if out.err != nil {
 			state := a2aproto.TaskStateFailed
 			if errors.Is(out.err, context.Canceled) {

--- a/pkg/bridges/a2a/server.go
+++ b/pkg/bridges/a2a/server.go
@@ -29,6 +29,14 @@ func NewServer(runner agentadaptor.Runner, opts ServerOptions) *Server {
 	if runner == nil {
 		panic("a2a bridge: nil runner")
 	}
+	if opts.StreamWire == StreamWireStatusData {
+		opts.AgentCard.Capabilities.Extensions = append(opts.AgentCard.Capabilities.Extensions, Extension{
+			URI:         AdapterStreamExtensionURI,
+			Description: "Streams agent-adaptor intermediate events through TaskStatusUpdateEvent DataParts.",
+			Required:    false,
+			Params:      map[string]any{"schema": AdapterStreamSchemaV1},
+		})
+	}
 	card, err := buildAgentCard(opts.AgentCard)
 	if err != nil {
 		panic(err)
@@ -52,6 +60,7 @@ func NewServer(runner agentadaptor.Runner, opts ServerOptions) *Server {
 		runner: runner, session: opts.Session, prompt: promptBuilder,
 		runOptions:    append([]agentadaptor.RunOption(nil), opts.RunOptions...),
 		runStreaming:  opts.RunStreaming,
+		streamWire:    opts.StreamWire,
 		resultBuilder: opts.ResultBuilder,
 		exposure:      opts.Exposure,
 		active:        map[a2aproto.TaskID]agentadaptor.RunHandle{},
@@ -93,6 +102,7 @@ type executor struct {
 	prompt        PromptBuilder
 	runOptions    []agentadaptor.RunOption
 	runStreaming  RunStreamingMode
+	streamWire    StreamWireMode
 	resultBuilder ResultBuilder
 	exposure      ExposurePolicy
 
@@ -172,7 +182,7 @@ func (e *executor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext)
 		defer e.delete(execCtx.TaskID)
 
 		// 3. Forward stream payloads while Wait collects the terminal SDK result.
-		translator := newStreamTranslator(execCtx, e.exposure)
+		translator := newStreamTranslator(execCtx, e.exposure, e.streamWire)
 		waitCh := make(chan waitResult, 1)
 		go func() {
 			result, err := handle.Wait(runCtx)

--- a/pkg/bridges/a2a/server_test.go
+++ b/pkg/bridges/a2a/server_test.go
@@ -747,6 +747,60 @@ func TestSendStreamingMessageEmitsOrderedUpdates(t *testing.T) {
 	}
 }
 
+func TestSendStreamingMessageStatusDataModeAvoidsIntermediateArtifacts(t *testing.T) {
+	t.Parallel()
+	opts := testOptions()
+	opts.StreamWire = a2a.StreamWireStatusData
+	server := a2a.NewServer(scriptedRunner{start: func(ctx context.Context, prompt string, runOpts ...agentadaptor.RunOption) (agentadaptor.RunHandle, error) {
+		h := newScriptedHandle("run-status-data")
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			h.emit(agentadaptor.StreamPayload{Kind: agentadaptor.StreamTextStart, Sequence: 1, MessageID: "msg-1"})
+			h.emit(agentadaptor.StreamPayload{Kind: agentadaptor.StreamTextContent, Sequence: 2, MessageID: "msg-1", Delta: "hello"})
+			h.emit(agentadaptor.StreamPayload{Kind: agentadaptor.StreamTextEnd, Sequence: 3, MessageID: "msg-1"})
+			h.finish(agentadaptor.RunResult{RunID: "run-status-data", Output: "hello", Summary: "done"}, nil)
+		}()
+		return h, nil
+	}}, opts)
+
+	resp := postRPC(t, server.Handler(), `{"jsonrpc":"2.0","id":"stream","method":"SendStreamingMessage","params":{"message":{"messageId":"m1","role":"ROLE_USER","parts":[{"text":"stream"}]}}}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	frames := readSSEFrames(t, resp.Body, 2*time.Second)
+	var streamKinds []string
+	for _, frame := range frames {
+		if frame.Result.ArtifactUpdate != nil && frame.Result.ArtifactUpdate.Artifact.Name == a2a.ArtifactAssistantOutput {
+			t.Fatalf("unexpected intermediate assistant artifact: %+v", frame)
+		}
+		if frame.Result.StatusUpdate == nil {
+			continue
+		}
+		for _, part := range frame.Result.StatusUpdate.Status.Message.Parts {
+			if part.Data["schema"] != a2a.AdapterStreamSchemaV1 {
+				continue
+			}
+			event, _ := part.Data["event"].(map[string]any)
+			streamKinds = append(streamKinds, fmt.Sprint(event["kind"]))
+		}
+	}
+	want := []string{"text.start", "text.content", "text.end"}
+	if fmt.Sprint(streamKinds) != fmt.Sprint(want) {
+		t.Fatalf("stream kinds = %v, want %v, frames=%+v", streamKinds, want, frames)
+	}
+	card := server.AgentCard()
+	foundExtension := false
+	for _, extension := range card.Capabilities.Extensions {
+		if extension.URI == a2a.AdapterStreamExtensionURI {
+			foundExtension = true
+		}
+	}
+	if !foundExtension {
+		t.Fatalf("agent card extensions = %+v", card.Capabilities.Extensions)
+	}
+}
+
 func TestCancelTaskCancelsUnderlyingRun(t *testing.T) {
 	t.Parallel()
 
@@ -1040,7 +1094,13 @@ type sseFrame struct {
 		} `json:"task"`
 		StatusUpdate *struct {
 			Status struct {
-				State string `json:"state"`
+				State   string `json:"state"`
+				Message struct {
+					Parts []struct {
+						Text string         `json:"text"`
+						Data map[string]any `json:"data"`
+					} `json:"parts"`
+				} `json:"message"`
 			} `json:"status"`
 		} `json:"statusUpdate"`
 		ArtifactUpdate *struct {

--- a/pkg/bridges/a2a/server_test.go
+++ b/pkg/bridges/a2a/server_test.go
@@ -92,8 +92,12 @@ func TestAgentCardIntrospectionPreservesConfiguredDetails(t *testing.T) {
 	if card.Provider == nil || card.Provider.Organization != "Agent Dance" {
 		t.Fatalf("provider not preserved: %+v", card.Provider)
 	}
-	if card.Capabilities.Streaming != a2a.CapabilityEnabled || len(card.Capabilities.Extensions) != 1 {
+	if card.Capabilities.Streaming != a2a.CapabilityEnabled || len(card.Capabilities.Extensions) != 2 {
 		t.Fatalf("capabilities not preserved: %+v", card.Capabilities)
+	}
+	if card.Capabilities.Extensions[0].URI != "https://example.com/ext" ||
+		card.Capabilities.Extensions[1].URI != a2a.AdapterStreamExtensionURI {
+		t.Fatalf("extensions = %+v", card.Capabilities.Extensions)
 	}
 	if len(card.Skills) != 1 || len(card.Skills[0].Tags) != 1 || len(card.Skills[0].Examples) != 1 || len(card.Skills[0].InputModes) != 1 {
 		t.Fatalf("skill details not preserved: %+v", card.Skills)
@@ -730,14 +734,19 @@ func TestSendStreamingMessageEmitsOrderedUpdates(t *testing.T) {
 	if frames[1].Result.StatusUpdate == nil || frames[1].Result.StatusUpdate.Status.State != "TASK_STATE_WORKING" {
 		t.Fatalf("second frame should be working: %+v", frames[1])
 	}
-	if frames[2].Result.ArtifactUpdate == nil || frames[2].Result.ArtifactUpdate.Artifact.Name != a2a.ArtifactAssistantOutput || frames[2].Result.ArtifactUpdate.Artifact.Parts[0].Text != "hel" || frames[2].Result.ArtifactUpdate.LastChunk {
-		t.Fatalf("third frame should be artifact hel: %+v", frames[2])
-	}
-	if frames[3].Result.ArtifactUpdate == nil || frames[3].Result.ArtifactUpdate.Artifact.Name != a2a.ArtifactAssistantOutput || frames[3].Result.ArtifactUpdate.Artifact.Parts[0].Text != "lo" || frames[3].Result.ArtifactUpdate.LastChunk {
-		t.Fatalf("fourth frame should be artifact lo: %+v", frames[3])
-	}
-	if frames[4].Result.ArtifactUpdate == nil || frames[4].Result.ArtifactUpdate.Artifact.Name != a2a.ArtifactAssistantOutput || !frames[4].Result.ArtifactUpdate.LastChunk {
-		t.Fatalf("fifth frame should close assistant-output: %+v", frames[4])
+	for i, kind := range []string{"text.content", "text.content", "text.end"} {
+		frame := frames[i+2]
+		if frame.Result.StatusUpdate == nil || len(frame.Result.StatusUpdate.Status.Message.Parts) == 0 {
+			t.Fatalf("frame %d should be a status update: %+v", i+2, frame)
+		}
+		part := frame.Result.StatusUpdate.Status.Message.Parts[0]
+		if part.Data["schema"] != a2a.AdapterStreamSchemaV1 {
+			t.Fatalf("frame %d schema = %#v", i+2, part.Data)
+		}
+		event, _ := part.Data["event"].(map[string]any)
+		if fmt.Sprint(event["kind"]) != kind {
+			t.Fatalf("frame %d kind = %#v, want %s", i+2, event["kind"], kind)
+		}
 	}
 	if frames[5].Result.ArtifactUpdate == nil || frames[5].Result.ArtifactUpdate.Artifact.Name != a2a.ArtifactAgentAdaptorResult || !frames[5].Result.ArtifactUpdate.LastChunk {
 		t.Fatalf("sixth frame should close agent-adaptor-result: %+v", frames[5])
@@ -747,10 +756,9 @@ func TestSendStreamingMessageEmitsOrderedUpdates(t *testing.T) {
 	}
 }
 
-func TestSendStreamingMessageStatusDataModeAvoidsIntermediateArtifacts(t *testing.T) {
+func TestSendStreamingMessageAvoidsIntermediateArtifacts(t *testing.T) {
 	t.Parallel()
 	opts := testOptions()
-	opts.StreamWire = a2a.StreamWireStatusData
 	server := a2a.NewServer(scriptedRunner{start: func(ctx context.Context, prompt string, runOpts ...agentadaptor.RunOption) (agentadaptor.RunHandle, error) {
 		h := newScriptedHandle("run-status-data")
 		go func() {
@@ -771,8 +779,8 @@ func TestSendStreamingMessageStatusDataModeAvoidsIntermediateArtifacts(t *testin
 	frames := readSSEFrames(t, resp.Body, 2*time.Second)
 	var streamKinds []string
 	for _, frame := range frames {
-		if frame.Result.ArtifactUpdate != nil && frame.Result.ArtifactUpdate.Artifact.Name == a2a.ArtifactAssistantOutput {
-			t.Fatalf("unexpected intermediate assistant artifact: %+v", frame)
+		if frame.Result.ArtifactUpdate != nil && frame.Result.ArtifactUpdate.Artifact.Name != a2a.ArtifactAgentAdaptorResult {
+			t.Fatalf("unexpected intermediate artifact: %+v", frame)
 		}
 		if frame.Result.StatusUpdate == nil {
 			continue

--- a/pkg/bridges/a2a/stream_status.go
+++ b/pkg/bridges/a2a/stream_status.go
@@ -1,0 +1,160 @@
+package a2a
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	agentadaptor "github.com/agent-dance/agent-adaptor"
+)
+
+const (
+	// AdapterStreamSchemaV1 标识 Adapter StreamPayload 的 A2A DataPart wire schema。
+	AdapterStreamSchemaV1 = "adapter.stream.v1"
+	// AdapterStreamExtensionURI 是 Agent Card 声明 adapter.stream.v1 能力的扩展 URI。
+	AdapterStreamExtensionURI = "urn:agent-adaptor:stream:v1"
+	adapterStreamMaxBytes     = 64 * 1024
+)
+
+// AdapterStreamEnvelopeV1 是内置 Agent 在 StatusUpdate DataPart 中使用的稳定信封。
+type AdapterStreamEnvelopeV1 struct {
+	Schema string               `json:"schema"`
+	Event  AdapterStreamEventV1 `json:"event"`
+}
+
+// AdapterStreamEventV1 是 StreamPayload 的 A2A wire DTO。
+type AdapterStreamEventV1 struct {
+	Kind       string         `json:"kind"`
+	Sequence   uint64         `json:"sequence,omitempty"`
+	RunID      string         `json:"run_id,omitempty"`
+	ThreadID   string         `json:"thread_id,omitempty"`
+	TurnID     string         `json:"turn_id,omitempty"`
+	MessageID  string         `json:"message_id,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	Delta      string         `json:"delta,omitempty"`
+	Args       map[string]any `json:"args,omitempty"`
+	Result     map[string]any `json:"result,omitempty"`
+	Role       string         `json:"role,omitempty"`
+	Timestamp  string         `json:"timestamp,omitempty"`
+	HITL       map[string]any `json:"hitl,omitempty"`
+	Raw        map[string]any `json:"raw,omitempty"`
+}
+
+func encodeAdapterStreamStatus(p agentadaptor.StreamPayload, exposure ExposurePolicy) (map[string]any, error) {
+	event := AdapterStreamEventV1{
+		Kind:       string(p.Kind),
+		Sequence:   p.Sequence,
+		RunID:      p.RunID,
+		ThreadID:   p.ThreadID,
+		TurnID:     p.TurnID,
+		MessageID:  p.MessageID,
+		ToolCallID: p.ToolCallID,
+		Name:       p.Name,
+		Delta:      redactInlineSecrets(p.Delta),
+		Role:       string(p.Role),
+	}
+	if event.Sequence == 0 {
+		event.Sequence = p.Seq
+	}
+	if !p.Timestamp.IsZero() {
+		event.Timestamp = p.Timestamp.UTC().Format(time.RFC3339Nano)
+	}
+	if len(p.Args) > 0 {
+		event.Args = sanitizeRemoteMap(p.Args)
+	}
+	if len(p.Result) > 0 {
+		event.Result = sanitizeRemoteMap(p.Result)
+	}
+	switch p.Kind {
+	case agentadaptor.StreamHITLRequested:
+		event.HITL = hitlRequestedArtifact(p, exposure)
+	case agentadaptor.StreamHITLResolved:
+		event.HITL = hitlResolvedArtifact(p, exposure)
+	case agentadaptor.StreamDropped:
+		event.Raw = sanitizeRemoteMap(p.Raw)
+	}
+	envelope := AdapterStreamEnvelopeV1{Schema: AdapterStreamSchemaV1, Event: event}
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, fmt.Errorf("marshal adapter stream status: %w", err)
+	}
+	if len(raw) > adapterStreamMaxBytes {
+		return nil, fmt.Errorf("adapter stream status exceeds %d bytes", adapterStreamMaxBytes)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("normalize adapter stream status: %w", err)
+	}
+	return data, nil
+}
+
+// DecodeAdapterStreamStatus 将 adapter.stream.v1 DataPart 还原为 StreamPayload。
+// matched=false 表示 data 不属于该 schema；属于该 schema 但非法时返回错误。
+func DecodeAdapterStreamStatus(data any) (payload agentadaptor.StreamPayload, matched bool, err error) {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return payload, false, nil
+	}
+	var header struct {
+		Schema string `json:"schema"`
+	}
+	if err := json.Unmarshal(raw, &header); err != nil || header.Schema != AdapterStreamSchemaV1 {
+		return payload, false, nil
+	}
+	if len(raw) > adapterStreamMaxBytes {
+		return payload, true, fmt.Errorf("adapter stream status exceeds %d bytes", adapterStreamMaxBytes)
+	}
+	var envelope AdapterStreamEnvelopeV1
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return payload, true, fmt.Errorf("decode adapter stream status: %w", err)
+	}
+	event := envelope.Event
+	if strings.TrimSpace(event.Kind) == "" {
+		return payload, true, errors.New("adapter stream status kind is empty")
+	}
+	if !supportedAdapterStreamKind(agentadaptor.StreamKind(event.Kind)) {
+		return payload, true, fmt.Errorf("unsupported adapter stream status kind %q", event.Kind)
+	}
+	payload = agentadaptor.StreamPayload{
+		Kind:       agentadaptor.StreamKind(event.Kind),
+		Sequence:   event.Sequence,
+		Seq:        event.Sequence,
+		RunID:      event.RunID,
+		ThreadID:   event.ThreadID,
+		TurnID:     event.TurnID,
+		MessageID:  event.MessageID,
+		ToolCallID: event.ToolCallID,
+		Name:       event.Name,
+		Delta:      event.Delta,
+		Args:       event.Args,
+		Result:     event.Result,
+		Role:       agentadaptor.Role(event.Role),
+		Raw:        event.Raw,
+	}
+	if event.Timestamp != "" {
+		payload.Timestamp, err = time.Parse(time.RFC3339Nano, event.Timestamp)
+		if err != nil {
+			return agentadaptor.StreamPayload{}, true, fmt.Errorf("decode adapter stream timestamp: %w", err)
+		}
+	}
+	if len(event.HITL) > 0 {
+		payload.Raw = cloneMap(event.HITL)
+	}
+	return payload, true, nil
+}
+
+func supportedAdapterStreamKind(kind agentadaptor.StreamKind) bool {
+	switch kind {
+	case agentadaptor.StreamTextStart, agentadaptor.StreamTextContent, agentadaptor.StreamTextEnd,
+		agentadaptor.StreamToolCallStart, agentadaptor.StreamToolCallArgs, agentadaptor.StreamToolCallEnd,
+		agentadaptor.StreamToolCallResult, agentadaptor.StreamReasoningStart,
+		agentadaptor.StreamReasoningContent, agentadaptor.StreamReasoningEnd,
+		agentadaptor.StreamHITLRequested, agentadaptor.StreamHITLResolved, agentadaptor.StreamDropped:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/bridges/a2a/types.go
+++ b/pkg/bridges/a2a/types.go
@@ -160,6 +160,16 @@ const (
 	RunStreamingDisabled
 )
 
+// StreamWireMode 控制 SDK 中间 StreamPayload 在 A2A 边界的编码方式。
+type StreamWireMode uint8
+
+const (
+	// StreamWireLegacyArtifact 保持历史 ArtifactUpdate 编码，作为默认兼容模式。
+	StreamWireLegacyArtifact StreamWireMode = iota
+	// StreamWireStatusData 将中间事件编码为 StatusUpdate DataPart。
+	StreamWireStatusData
+)
+
 type ServerOptions struct {
 	// AgentCard is the public discovery document advertised by this local A2A
 	// server.
@@ -182,6 +192,9 @@ type ServerOptions struct {
 	// each run. Disable this when a provider's structured-output path is
 	// incompatible with Streaming=true.
 	RunStreaming RunStreamingMode
+	// StreamWire controls how intermediate StreamPayload events cross the A2A
+	// boundary. The zero value preserves the historical ArtifactUpdate format.
+	StreamWire StreamWireMode
 	// ResultBuilder customizes the terminal A2A projection (status text and
 	// terminal artifacts) produced from one completed SDK run.
 	ResultBuilder ResultBuilder

--- a/pkg/bridges/a2a/types.go
+++ b/pkg/bridges/a2a/types.go
@@ -104,9 +104,6 @@ const (
 )
 
 const (
-	// ArtifactAssistantOutput is the bridge-owned A2A artifact name used for
-	// streamed assistant-facing text deltas.
-	ArtifactAssistantOutput = "assistant-output"
 	// ArtifactAgentAdaptorResult is the bridge-owned A2A artifact name used
 	// for the terminal structured SDK result summary and opt-in diagnostics.
 	ArtifactAgentAdaptorResult = "agent-adaptor-result"
@@ -160,16 +157,6 @@ const (
 	RunStreamingDisabled
 )
 
-// StreamWireMode 控制 SDK 中间 StreamPayload 在 A2A 边界的编码方式。
-type StreamWireMode uint8
-
-const (
-	// StreamWireLegacyArtifact 保持历史 ArtifactUpdate 编码，作为默认兼容模式。
-	StreamWireLegacyArtifact StreamWireMode = iota
-	// StreamWireStatusData 将中间事件编码为 StatusUpdate DataPart。
-	StreamWireStatusData
-)
-
 type ServerOptions struct {
 	// AgentCard is the public discovery document advertised by this local A2A
 	// server.
@@ -192,9 +179,6 @@ type ServerOptions struct {
 	// each run. Disable this when a provider's structured-output path is
 	// incompatible with Streaming=true.
 	RunStreaming RunStreamingMode
-	// StreamWire controls how intermediate StreamPayload events cross the A2A
-	// boundary. The zero value preserves the historical ArtifactUpdate format.
-	StreamWire StreamWireMode
 	// ResultBuilder customizes the terminal A2A projection (status text and
 	// terminal artifacts) produced from one completed SDK run.
 	ResultBuilder ResultBuilder

--- a/pkg/hosttools/a2adelegation/delegator.go
+++ b/pkg/hosttools/a2adelegation/delegator.go
@@ -41,15 +41,37 @@ type A2AClient interface {
 type ClientFactory func(RemoteAgentSpec) A2AClient
 
 type Delegator struct {
-	Registry      *Registry
-	Bus           *EventBus
-	NewClient     ClientFactory
-	NewID         func() string
-	LifecycleHook DelegationLifecycleHook
+	Registry       *Registry
+	Bus            *EventBus
+	NewClient      ClientFactory
+	NewID          func() string
+	LifecycleHook  DelegationLifecycleHook
+	statusDecoders []StatusPartDecoder
 }
 
-func NewDelegator(registry *Registry, bus *EventBus) *Delegator {
-	return &Delegator{Registry: registry, Bus: bus}
+// DelegatorOption 配置 Delegator 的扩展行为。
+type DelegatorOption func(*Delegator)
+
+// WithStatusPartDecoder 注册一种宿主拥有的 Status DataPart schema decoder。
+func WithStatusPartDecoder(decoder StatusPartDecoder) DelegatorOption {
+	return func(d *Delegator) {
+		if decoder != nil {
+			d.statusDecoders = append(d.statusDecoders, decoder)
+		}
+	}
+}
+
+func NewDelegator(registry *Registry, bus *EventBus, opts ...DelegatorOption) *Delegator {
+	d := &Delegator{
+		Registry: registry,
+		Bus:      bus,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(d)
+		}
+	}
+	return d
 }
 
 type delegationRun struct {
@@ -207,7 +229,7 @@ func (r *delegationRun) delegateStreaming(ctx context.Context, client A2AClient,
 	}
 	defer stream.Close()
 	// 2. Track remote identity and mapper state for recovery and lifecycle closure.
-	mapper := newEventMapper(baseEvent)
+	mapper := newEventMapper(baseEvent, r.statusDecoders...)
 	var lastTask clienta2a.Task
 	lastTaskID := ""
 	cancelResult := func() (DelegationResult, error) {
@@ -355,7 +377,7 @@ func (r *delegationRun) delegatePolling(ctx context.Context, client A2AClient, s
 		baseResult.Error = derr
 		return baseResult, derr
 	}
-	mapper := newEventMapper(baseEvent)
+	mapper := newEventMapper(baseEvent, r.statusDecoders...)
 	r.publish(mapper.Started(task.ID, task.ContextID))
 	for _, ev := range mapper.taskEvents(task) {
 		r.publish(ev)
@@ -585,7 +607,7 @@ func failedEvent(base DelegationEvent, derr *DelegationError) DelegationEvent {
 
 func (r *delegationRun) finishTask(baseEvent DelegationEvent, baseResult DelegationResult, task clienta2a.Task, policy DelegationPolicy, maxArtifacts *int, includeRemoteArtifacts bool, mapper *eventMapper) (DelegationResult, error) {
 	if mapper == nil {
-		mapper = newEventMapper(baseEvent)
+		mapper = newEventMapper(baseEvent, r.statusDecoders...)
 	}
 	if derr := policyErrorForTask(task, policy); derr != nil {
 		r.publishAll(mapper.closeOpen(task.ID, task.ContextID))

--- a/pkg/hosttools/a2adelegation/delegator_test.go
+++ b/pkg/hosttools/a2adelegation/delegator_test.go
@@ -121,7 +121,7 @@ func TestToolSchemaAllowsOnlyRegistryKeyObjectiveInputAndConstraints(t *testing.
 	}
 }
 
-func TestEventMapperMapsA2ABridgeArtifactsAndTerminal(t *testing.T) {
+func TestEventMapperMapsA2AArtifactsAndTerminal(t *testing.T) {
 	t.Parallel()
 	mapper := newEventMapper(DelegationEvent{RunID: "run-1", DelegationID: "del-1", AgentKey: "research"})
 	events := mapper.Map(clienta2a.Event{
@@ -130,14 +130,14 @@ func TestEventMapperMapsA2ABridgeArtifactsAndTerminal(t *testing.T) {
 		ContextID: "ctx-1",
 		Artifact: &clienta2a.Artifact{
 			ID:    "assistant-output",
-			Name:  bridgea2a.ArtifactAssistantOutput,
+			Name:  "assistant-output",
 			Parts: []clienta2a.Part{{Kind: clienta2a.PartText, Text: "hello"}},
 		},
 	})
-	if len(events) != 3 {
-		t.Fatalf("expected delegation + synthesized text start/delta, got %#v", events)
+	if len(events) != 2 {
+		t.Fatalf("expected delegation + final artifact, got %#v", events)
 	}
-	if events[0].Kind != DelegationStarted || events[1].Kind != DelegationTextStart || events[2].Kind != DelegationTextDelta || events[2].Delta != "hello" {
+	if events[0].Kind != DelegationStarted || events[1].Kind != DelegationArtifactCreated {
 		t.Fatalf("unexpected mapped events: %#v", events)
 	}
 

--- a/pkg/hosttools/a2adelegation/delegator_test.go
+++ b/pkg/hosttools/a2adelegation/delegator_test.go
@@ -1047,6 +1047,29 @@ func TestEventBusTerminalDeliveryDropsOldestWhenSubscriberFull(t *testing.T) {
 	}
 }
 
+func TestEventBusReportsBackpressureWhenSubscriberFull(t *testing.T) {
+	t.Parallel()
+	bus := NewEventBus(0)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := bus.SubscribeRun(ctx, "run-1")
+	for i := 0; i < subscriberBuffer; i++ {
+		bus.Publish(DelegationEvent{RunID: "run-1", DelegationID: "del-1", Kind: DelegationTextDelta, Sequence: uint64(i + 1)})
+	}
+	bus.Publish(DelegationEvent{RunID: "run-1", DelegationID: "del-1", Kind: DelegationTextDelta, Sequence: subscriberBuffer + 1})
+
+	var dropped *DelegationEvent
+	for i := 0; i < subscriberBuffer; i++ {
+		event := <-ch
+		if event.Kind == DelegationStreamDropped {
+			dropped = &event
+		}
+	}
+	if dropped == nil || dropped.Raw["reason"] != "event_bus_backpressure" || dropped.Raw["dropped_count"] != 2 {
+		t.Fatalf("backpressure event = %#v", dropped)
+	}
+}
+
 func TestEventBusPreservesTextEndBeforeTerminalForFullSubscriber(t *testing.T) {
 	t.Parallel()
 	bus := NewEventBus(0)

--- a/pkg/hosttools/a2adelegation/events.go
+++ b/pkg/hosttools/a2adelegation/events.go
@@ -67,11 +67,31 @@ func deliverSubscriber(ch chan DelegationEvent, ev DelegationEvent) {
 		return
 	default:
 	}
-	if !isPriorityEvent(ev.Kind) {
+	if !isPriorityEvent(ev) {
+		var oldest DelegationEvent
+		select {
+		case oldest = <-ch:
+		default:
+			return
+		}
+		dropEvent := backpressureEvent(ev, []DelegationEvent{oldest, ev})
+		select {
+		case ch <- dropEvent:
+		default:
+		}
 		return
 	}
+	dropped := make([]DelegationEvent, 0, 2)
+	for i := 0; i < 2; i++ {
+		select {
+		case oldest := <-ch:
+			dropped = append(dropped, oldest)
+		default:
+		}
+	}
+	dropEvent := backpressureEvent(ev, dropped)
 	select {
-	case <-ch:
+	case ch <- dropEvent:
 	default:
 	}
 	select {
@@ -80,8 +100,33 @@ func deliverSubscriber(ch chan DelegationEvent, ev DelegationEvent) {
 	}
 }
 
-func isPriorityEvent(kind DelegationEventKind) bool {
-	return kind == DelegationTextEnd || kind == DelegationToolCallEnd || isTerminal(kind)
+func backpressureEvent(current DelegationEvent, dropped []DelegationEvent) DelegationEvent {
+	event := current
+	event.Kind = DelegationStreamDropped
+	event.Sequence = 0
+	event.Delta = ""
+	event.Args = nil
+	event.Result = nil
+	event.Artifact = nil
+	event.Raw = map[string]any{
+		"reason":        "event_bus_backpressure",
+		"dropped_count": len(dropped),
+	}
+	details := make([]map[string]any, 0, len(dropped))
+	for _, item := range dropped {
+		details = append(details, map[string]any{
+			"delegation_id": item.DelegationID,
+			"kind":          string(item.Kind),
+			"sequence":      item.Sequence,
+		})
+	}
+	event.Raw["dropped_events"] = details
+	return event
+}
+
+func isPriorityEvent(ev DelegationEvent) bool {
+	return ev.Kind == DelegationTextEnd || ev.Kind == DelegationReasoningEnd ||
+		ev.Kind == DelegationToolCallEnd || ev.Kind == DelegationStreamDropped || isTerminal(ev.Kind)
 }
 
 func (b *EventBus) ClearRun(runID string) {

--- a/pkg/hosttools/a2adelegation/mapping.go
+++ b/pkg/hosttools/a2adelegation/mapping.go
@@ -1,6 +1,8 @@
 package a2adelegation
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"strings"
 
@@ -9,14 +11,26 @@ import (
 )
 
 type eventMapper struct {
-	base        DelegationEvent
-	started     bool
-	openMessage string
+	base           DelegationEvent
+	started        bool
+	openMessage    string
+	statusDecoders []StatusPartDecoder
+	streamProfile  string
+	lastSequence   uint64
+	seenStatusData map[string]struct{}
+	seenStatusText map[string]struct{}
 }
 
-func newEventMapper(base DelegationEvent) *eventMapper {
+func newEventMapper(base DelegationEvent, decoders ...StatusPartDecoder) *eventMapper {
 	base.Protocol = ProtocolA2A
-	return &eventMapper{base: base}
+	statusDecoders := []StatusPartDecoder{adapterStreamStatusDecoder{}}
+	statusDecoders = append(statusDecoders, decoders...)
+	return &eventMapper{
+		base:           base,
+		statusDecoders: statusDecoders,
+		seenStatusData: map[string]struct{}{},
+		seenStatusText: map[string]struct{}{},
+	}
 }
 
 func (m *eventMapper) Started(taskID, contextID string) DelegationEvent {
@@ -36,7 +50,7 @@ func (m *eventMapper) Map(event clienta2a.Event) []DelegationEvent {
 	}
 	switch event.Kind {
 	case clienta2a.EventStatus:
-		out = append(out, m.statusEvent(event.TaskID, event.ContextID, event.Status))
+		out = append(out, m.statusEvents(event.TaskID, event.ContextID, event.Status)...)
 	case clienta2a.EventTask:
 		if event.Task != nil {
 			out = append(out, m.taskEvents(*event.Task)...)
@@ -50,6 +64,11 @@ func (m *eventMapper) Map(event clienta2a.Event) []DelegationEvent {
 			out = append(out, m.artifactEvents(event)...)
 		}
 	case clienta2a.EventTerminal:
+		if event.Status != nil {
+			out = append(out, m.statusEvents(event.TaskID, event.ContextID, event.Status)...)
+		} else if event.Task != nil && event.Task.Status.State != "" {
+			out = append(out, m.statusEvents(event.Task.ID, event.Task.ContextID, &event.Task.Status)...)
+		}
 		if event.Message != nil {
 			out = append(out, m.messageEvents(*event.Message)...)
 		}
@@ -60,7 +79,7 @@ func (m *eventMapper) Map(event clienta2a.Event) []DelegationEvent {
 func (m *eventMapper) taskEvents(task clienta2a.Task) []DelegationEvent {
 	out := []DelegationEvent{}
 	if task.Status.State != "" {
-		out = append(out, m.statusEvent(task.ID, task.ContextID, &task.Status))
+		out = append(out, m.statusEvents(task.ID, task.ContextID, &task.Status)...)
 	}
 	for _, artifact := range task.Artifacts {
 		out = append(out, m.artifactEvents(clienta2a.Event{
@@ -69,6 +88,169 @@ func (m *eventMapper) taskEvents(task clienta2a.Task) []DelegationEvent {
 		})...)
 	}
 	return out
+}
+
+func (m *eventMapper) statusEvents(taskID, contextID string, status *clienta2a.TaskStatus) []DelegationEvent {
+	base := m.statusEvent(taskID, contextID, status)
+	out := []DelegationEvent{base}
+	if status == nil || status.Message == nil {
+		return out
+	}
+	message := *status.Message
+	out = append(out, m.statusPartEvents(taskID, contextID, message)...)
+	if m.streamProfile == "" || (m.streamProfile != bridgea2a.AdapterStreamSchemaV1 && m.streamProfile != "legacy_artifact_stream") {
+		out = append(out, m.statusTextEvents(taskID, contextID, message)...)
+	}
+	return out
+}
+
+func (m *eventMapper) statusPartEvents(taskID, contextID string, message clienta2a.Message) []DelegationEvent {
+	var out []DelegationEvent
+	for _, part := range message.Parts {
+		if part.Kind != clienta2a.PartData {
+			continue
+		}
+		for _, decoder := range m.statusDecoders {
+			if decoder == nil || strings.TrimSpace(decoder.Profile()) == "" {
+				continue
+			}
+			decoded, matched, err := decoder.DecodeStatusPart(part.Data)
+			if !matched {
+				continue
+			}
+			profile := decoder.Profile()
+			if !m.claimStreamProfile(profile) {
+				break
+			}
+			fingerprint := statusDataFingerprint(profile, message.ID, part.Data)
+			if _, seen := m.seenStatusData[fingerprint]; seen {
+				break
+			}
+			m.seenStatusData[fingerprint] = struct{}{}
+			if err != nil {
+				out = append(out, m.droppedEvent(taskID, contextID, profile, 0, map[string]any{"reason": err.Error()}))
+				break
+			}
+			sequence := firstStatusSequence(decoded)
+			if sequence != 0 {
+				if sequence <= m.lastSequence {
+					break
+				}
+				if m.lastSequence != 0 && sequence > m.lastSequence+1 {
+					out = append(out, m.droppedEvent(taskID, contextID, profile, 0, map[string]any{
+						"dropped_count": sequence - m.lastSequence - 1,
+						"first_missing": m.lastSequence + 1,
+						"last_missing":  sequence - 1,
+					}))
+				}
+				m.lastSequence = sequence
+			}
+			for _, event := range decoded {
+				out = append(out, m.delegationEventFromStatus(taskID, contextID, message.ID, profile, event))
+			}
+			break
+		}
+	}
+	return out
+}
+
+func (m *eventMapper) statusTextEvents(taskID, contextID string, message clienta2a.Message) []DelegationEvent {
+	text := textFromMessage(message)
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+	messageID := strings.TrimSpace(message.ID)
+	if messageID == "" {
+		messageID = m.base.DelegationID + ":status"
+	}
+	fingerprint := messageID + ":" + text
+	if _, seen := m.seenStatusText[fingerprint]; seen {
+		return nil
+	}
+	m.seenStatusText[fingerprint] = struct{}{}
+	start := m.base
+	start.Kind = DelegationTextStart
+	start.RemoteTaskID = taskID
+	start.RemoteContextID = contextID
+	start.RemoteMessageID = messageID
+	delta := start
+	delta.Kind = DelegationTextDelta
+	delta.Delta = text
+	end := start
+	end.Kind = DelegationTextEnd
+	return []DelegationEvent{start, delta, end}
+}
+
+func (m *eventMapper) delegationEventFromStatus(
+	taskID, contextID, messageID, profile string,
+	decoded StatusPartEvent,
+) DelegationEvent {
+	ev := m.base
+	ev.Kind = decoded.Kind
+	ev.RemoteTaskID = taskID
+	ev.RemoteContextID = contextID
+	ev.RemoteMessageID = decoded.MessageID
+	if ev.RemoteMessageID == "" {
+		ev.RemoteMessageID = messageID
+	}
+	ev.RemoteToolCallID = decoded.ToolCallID
+	ev.Sequence = decoded.Sequence
+	ev.Name = decoded.Name
+	ev.ToolName = decoded.Name
+	ev.Role = decoded.Role
+	ev.Delta = decoded.Delta
+	ev.Args = decoded.Args
+	ev.Result = decoded.Result
+	ev.Raw = cloneAnyMap(decoded.Raw)
+	if ev.Raw == nil {
+		ev.Raw = map[string]any{}
+	}
+	ev.Raw["stream_profile"] = profile
+	if !decoded.Time.IsZero() {
+		ev.Time = decoded.Time
+	}
+	return ev
+}
+
+func (m *eventMapper) droppedEvent(
+	taskID, contextID, profile string,
+	sequence uint64,
+	raw map[string]any,
+) DelegationEvent {
+	ev := m.base
+	ev.Kind = DelegationStreamDropped
+	ev.RemoteTaskID = taskID
+	ev.RemoteContextID = contextID
+	ev.Sequence = sequence
+	ev.Raw = cloneAnyMap(raw)
+	if ev.Raw == nil {
+		ev.Raw = map[string]any{}
+	}
+	ev.Raw["stream_profile"] = profile
+	return ev
+}
+
+func (m *eventMapper) claimStreamProfile(profile string) bool {
+	if m.streamProfile == "" {
+		m.streamProfile = profile
+		return true
+	}
+	return m.streamProfile == profile
+}
+
+func firstStatusSequence(events []StatusPartEvent) uint64 {
+	for _, event := range events {
+		if event.Sequence != 0 {
+			return event.Sequence
+		}
+	}
+	return 0
+}
+
+func statusDataFingerprint(profile, messageID string, data any) string {
+	raw, _ := json.Marshal(data)
+	digest := sha256.Sum256(raw)
+	return profile + ":" + messageID + ":" + hex.EncodeToString(digest[:])
 }
 
 func (m *eventMapper) statusEvent(taskID, contextID string, status *clienta2a.TaskStatus) DelegationEvent {
@@ -80,7 +262,9 @@ func (m *eventMapper) statusEvent(taskID, contextID string, status *clienta2a.Ta
 		ev.Status = string(status.State)
 		ev.Raw = map[string]any{"status": string(status.State)}
 		if status.Message != nil {
+			ev.RemoteMessageID = status.Message.ID
 			ev.Text = textFromMessage(*status.Message)
+			ev.StatusParts = cloneRemoteParts(status.Message.Parts)
 		}
 	}
 	return ev
@@ -123,6 +307,9 @@ func (m *eventMapper) messageEvents(msg clienta2a.Message) []DelegationEvent {
 
 func (m *eventMapper) artifactEvents(event clienta2a.Event) []DelegationEvent {
 	artifact := *event.Artifact
+	if legacyStreamArtifact(artifact.Name) && !m.claimStreamProfile("legacy_artifact_stream") {
+		return nil
+	}
 	if artifact.Name == bridgea2a.ArtifactAssistantOutput {
 		return m.assistantOutputEvents(event, artifact)
 	}
@@ -130,6 +317,11 @@ func (m *eventMapper) artifactEvents(event clienta2a.Event) []DelegationEvent {
 		return append([]DelegationEvent{m.artifactCreatedEvent(event, artifact)}, events...)
 	}
 	return []DelegationEvent{m.artifactCreatedEvent(event, artifact)}
+}
+
+func legacyStreamArtifact(name string) bool {
+	return name == bridgea2a.ArtifactAssistantOutput || name == "reasoning" || name == "stream-dropped" ||
+		name == "human-decision-request" || name == "human-decision-result" || strings.HasPrefix(name, "tool-call-")
 }
 
 func (m *eventMapper) artifactCreatedEvent(event clienta2a.Event, artifact clienta2a.Artifact) DelegationEvent {
@@ -384,13 +576,21 @@ func cloneRemoteArtifact(artifact clienta2a.Artifact) RemoteArtifact {
 		ID:          artifact.ID,
 		Name:        artifact.Name,
 		Description: artifact.Description,
+		Parts:       cloneRemoteParts(artifact.Parts),
 		Extensions:  append([]string(nil), artifact.Extensions...),
 		Metadata:    cloneAnyMap(artifact.Metadata),
 		Raw:         cloneAnyMap(artifact.Raw),
 	}
-	out.Parts = make([]RemotePart, 0, len(artifact.Parts))
-	for _, part := range artifact.Parts {
-		out.Parts = append(out.Parts, RemotePart{
+	return out
+}
+
+func cloneRemoteParts(parts []clienta2a.Part) []RemotePart {
+	if len(parts) == 0 {
+		return nil
+	}
+	out := make([]RemotePart, 0, len(parts))
+	for _, part := range parts {
+		out = append(out, RemotePart{
 			Kind:      part.Kind,
 			Text:      part.Text,
 			Raw:       append([]byte(nil), part.Raw...),

--- a/pkg/hosttools/a2adelegation/mapping.go
+++ b/pkg/hosttools/a2adelegation/mapping.go
@@ -181,8 +181,7 @@ func (m *eventMapper) statusTextEvents(taskID, contextID string, message clienta
 	return []DelegationEvent{start, delta, end}
 }
 
-// completeStatusDelegationEvent fills host-owned delegation and A2A context on
-// a semantic event returned by a StatusPartDecoder.
+// completeStatusDelegationEvent 为 decoder 返回的语义事件补齐当前 delegation 和 A2A 上下文。
 func (m *eventMapper) completeStatusDelegationEvent(
 	taskID, contextID, messageID, profile string,
 	decoded DelegationEvent,

--- a/pkg/hosttools/a2adelegation/mapping.go
+++ b/pkg/hosttools/a2adelegation/mapping.go
@@ -98,7 +98,7 @@ func (m *eventMapper) statusEvents(taskID, contextID string, status *clienta2a.T
 	}
 	message := *status.Message
 	out = append(out, m.statusPartEvents(taskID, contextID, message)...)
-	if m.streamProfile == "" || (m.streamProfile != bridgea2a.AdapterStreamSchemaV1 && m.streamProfile != "legacy_artifact_stream") {
+	if m.streamProfile != bridgea2a.AdapterStreamSchemaV1 {
 		out = append(out, m.statusTextEvents(taskID, contextID, message)...)
 	}
 	return out
@@ -307,21 +307,7 @@ func (m *eventMapper) messageEvents(msg clienta2a.Message) []DelegationEvent {
 
 func (m *eventMapper) artifactEvents(event clienta2a.Event) []DelegationEvent {
 	artifact := *event.Artifact
-	if legacyStreamArtifact(artifact.Name) && !m.claimStreamProfile("legacy_artifact_stream") {
-		return nil
-	}
-	if artifact.Name == bridgea2a.ArtifactAssistantOutput {
-		return m.assistantOutputEvents(event, artifact)
-	}
-	if events := m.toolCallEvents(event, artifact); len(events) > 0 {
-		return append([]DelegationEvent{m.artifactCreatedEvent(event, artifact)}, events...)
-	}
 	return []DelegationEvent{m.artifactCreatedEvent(event, artifact)}
-}
-
-func legacyStreamArtifact(name string) bool {
-	return name == bridgea2a.ArtifactAssistantOutput || name == "reasoning" || name == "stream-dropped" ||
-		name == "human-decision-request" || name == "human-decision-result" || strings.HasPrefix(name, "tool-call-")
 }
 
 func (m *eventMapper) artifactCreatedEvent(event clienta2a.Event, artifact clienta2a.Artifact) DelegationEvent {
@@ -340,128 +326,6 @@ func (m *eventMapper) artifactCreatedEvent(event clienta2a.Event, artifact clien
 	}
 	ev.Raw = artifact.Raw
 	return ev
-}
-
-// toolCallEvents restores the typed tool lifecycle encoded by the A2A bridge
-// as tool-call artifacts. This keeps A2A wire artifacts protocol-native while
-// giving hosts UI-facing events instead of opaque artifacts.
-func (m *eventMapper) toolCallEvents(event clienta2a.Event, artifact clienta2a.Artifact) []DelegationEvent {
-	if data := artifactData(artifact); data != nil {
-		toolID := dataString(data, "id")
-		switch dataString(data, "kind") {
-		case "tool_call.start":
-			ev := m.base
-			ev.Kind = DelegationToolCallStart
-			ev.RemoteTaskID = event.TaskID
-			ev.RemoteContextID = event.ContextID
-			ev.RemoteArtifactID = artifact.ID
-			ev.RemoteToolCallID = toolID
-			ev.ToolName = dataString(data, "name")
-			ev.Args = data["args"]
-			return []DelegationEvent{ev}
-		case "tool_call.result":
-			ev := m.base
-			ev.Kind = DelegationToolCallResult
-			ev.RemoteTaskID = event.TaskID
-			ev.RemoteContextID = event.ContextID
-			ev.RemoteArtifactID = artifact.ID
-			ev.RemoteToolCallID = toolID
-			ev.Result = data["result"]
-			return []DelegationEvent{ev}
-		case "tool_call.end":
-			ev := m.base
-			ev.Kind = DelegationToolCallEnd
-			ev.RemoteTaskID = event.TaskID
-			ev.RemoteContextID = event.ContextID
-			ev.RemoteArtifactID = artifact.ID
-			ev.RemoteToolCallID = toolID
-			return []DelegationEvent{ev}
-		}
-	}
-	if !strings.HasPrefix(artifact.Name, "tool-call-") {
-		return nil
-	}
-	toolID := strings.TrimPrefix(artifact.Name, "tool-call-")
-	ev := m.base
-	ev.RemoteTaskID = event.TaskID
-	ev.RemoteContextID = event.ContextID
-	ev.RemoteArtifactID = artifact.ID
-	ev.RemoteToolCallID = toolID
-	var out []DelegationEvent
-	if text := textFromParts(artifact.Parts); text != "" {
-		args := ev
-		args.Kind = DelegationToolCallArgs
-		args.Delta = text
-		out = append(out, args)
-	}
-	if event.LastChunk {
-		end := ev
-		end.Kind = DelegationToolCallEnd
-		out = append(out, end)
-	}
-	return out
-}
-
-func artifactData(artifact clienta2a.Artifact) map[string]any {
-	for _, part := range artifact.Parts {
-		if data, ok := part.Data.(map[string]any); ok {
-			return data
-		}
-	}
-	return nil
-}
-
-func dataString(data map[string]any, key string) string {
-	value, _ := data[key].(string)
-	return strings.TrimSpace(value)
-}
-
-// assistantOutputEvents 将 A2A 文本 artifact chunk 规范化为完整的文本消息生命周期。
-// A2A 用 append / lastChunk 标识 chunk 边界；下游 AG-UI 客户端则要求 start/content/end
-// 共享同一个 message ID，因此不能只透传 delta。
-func (m *eventMapper) assistantOutputEvents(event clienta2a.Event, artifact clienta2a.Artifact) []DelegationEvent {
-	messageID := artifact.ID
-	if messageID == "" {
-		messageID = bridgea2a.ArtifactAssistantOutput
-	}
-	out := make([]DelegationEvent, 0, 3)
-	if m.openMessage != messageID {
-		if m.openMessage != "" {
-			end := m.base
-			end.Kind = DelegationTextEnd
-			end.RemoteMessageID = m.openMessage
-			out = append(out, end)
-		}
-		start := m.base
-		start.Kind = DelegationTextStart
-		start.RemoteTaskID = event.TaskID
-		start.RemoteContextID = event.ContextID
-		start.RemoteArtifactID = artifact.ID
-		start.RemoteMessageID = messageID
-		out = append(out, start)
-		m.openMessage = messageID
-	}
-	if text := textFromParts(artifact.Parts); text != "" {
-		delta := m.base
-		delta.Kind = DelegationTextDelta
-		delta.RemoteTaskID = event.TaskID
-		delta.RemoteContextID = event.ContextID
-		delta.RemoteArtifactID = artifact.ID
-		delta.RemoteMessageID = messageID
-		delta.Delta = text
-		out = append(out, delta)
-	}
-	if event.LastChunk {
-		end := m.base
-		end.Kind = DelegationTextEnd
-		end.RemoteTaskID = event.TaskID
-		end.RemoteContextID = event.ContextID
-		end.RemoteArtifactID = artifact.ID
-		end.RemoteMessageID = messageID
-		out = append(out, end)
-		m.openMessage = ""
-	}
-	return out
 }
 
 func (m *eventMapper) closeOpen(taskID, contextID string) []DelegationEvent {
@@ -546,12 +410,6 @@ func resultFromTask(base DelegationResult, task clienta2a.Task, includeRemoteArt
 		}
 		if artifact.Name == bridgea2a.ArtifactAgentAdaptorResult {
 			applyAgentAdaptorResult(&base, artifact)
-			continue
-		}
-		if artifact.Name == bridgea2a.ArtifactAssistantOutput {
-			if text := textFromParts(artifact.Parts); text != "" && base.Summary == "" {
-				base.Summary = text
-			}
 			continue
 		}
 		base.Artifacts = append(base.Artifacts, DelegationArtifact{ID: artifact.ID, Name: artifact.Name, Description: artifact.Description, URI: firstURI(artifact.Parts), MediaType: firstMediaType(artifact.Parts), Metadata: cloneAnyMap(artifact.Metadata)})

--- a/pkg/hosttools/a2adelegation/mapping.go
+++ b/pkg/hosttools/a2adelegation/mapping.go
@@ -146,7 +146,7 @@ func (m *eventMapper) statusPartEvents(taskID, contextID string, message clienta
 				m.lastSequence = sequence
 			}
 			for _, event := range decoded {
-				out = append(out, m.delegationEventFromStatus(taskID, contextID, message.ID, profile, event))
+				out = append(out, m.completeStatusDelegationEvent(taskID, contextID, message.ID, profile, event))
 			}
 			break
 		}
@@ -181,33 +181,31 @@ func (m *eventMapper) statusTextEvents(taskID, contextID string, message clienta
 	return []DelegationEvent{start, delta, end}
 }
 
-func (m *eventMapper) delegationEventFromStatus(
+// completeStatusDelegationEvent fills host-owned delegation and A2A context on
+// a semantic event returned by a StatusPartDecoder.
+func (m *eventMapper) completeStatusDelegationEvent(
 	taskID, contextID, messageID, profile string,
-	decoded StatusPartEvent,
+	decoded DelegationEvent,
 ) DelegationEvent {
-	ev := m.base
-	ev.Kind = decoded.Kind
+	ev := decoded
+	ev.RunID = m.base.RunID
+	ev.ParentToolCallID = m.base.ParentToolCallID
+	ev.DelegationID = m.base.DelegationID
+	ev.AgentKey = m.base.AgentKey
+	ev.AgentName = m.base.AgentName
+	ev.Protocol = m.base.Protocol
 	ev.RemoteTaskID = taskID
 	ev.RemoteContextID = contextID
-	ev.RemoteMessageID = decoded.MessageID
 	if ev.RemoteMessageID == "" {
 		ev.RemoteMessageID = messageID
 	}
-	ev.RemoteToolCallID = decoded.ToolCallID
-	ev.Sequence = decoded.Sequence
-	ev.Name = decoded.Name
-	ev.ToolName = decoded.Name
-	ev.Role = decoded.Role
-	ev.Delta = decoded.Delta
-	ev.Args = decoded.Args
-	ev.Result = decoded.Result
 	ev.Raw = cloneAnyMap(decoded.Raw)
 	if ev.Raw == nil {
 		ev.Raw = map[string]any{}
 	}
 	ev.Raw["stream_profile"] = profile
-	if !decoded.Time.IsZero() {
-		ev.Time = decoded.Time
+	if ev.Time.IsZero() {
+		ev.Time = m.base.Time
 	}
 	return ev
 }
@@ -238,7 +236,7 @@ func (m *eventMapper) claimStreamProfile(profile string) bool {
 	return m.streamProfile == profile
 }
 
-func firstStatusSequence(events []StatusPartEvent) uint64 {
+func firstStatusSequence(events []DelegationEvent) uint64 {
 	for _, event := range events {
 		if event.Sequence != 0 {
 			return event.Sequence

--- a/pkg/hosttools/a2adelegation/mapping_test.go
+++ b/pkg/hosttools/a2adelegation/mapping_test.go
@@ -2,7 +2,9 @@ package a2adelegation
 
 import (
 	"testing"
+	"time"
 
+	agentadaptor "github.com/agent-dance/agent-adaptor"
 	bridgea2a "github.com/agent-dance/agent-adaptor/pkg/bridges/a2a"
 	clienta2a "github.com/agent-dance/agent-adaptor/pkg/clients/a2a"
 )
@@ -108,6 +110,58 @@ func TestEventMapperToolArtifactsFollowToolLifecycle(t *testing.T) {
 	}
 }
 
+// TestEventMapperStatusPreservesDataParts verifies that structured status data
+// survives the A2A-to-delegation mapping for host-owned projections.
+func TestEventMapperStatusPreservesDataParts(t *testing.T) {
+	mapper := newEventMapper(DelegationEvent{RunID: "run-1", DelegationID: "del-1", AgentKey: "implement"})
+	events := mapper.Map(clienta2a.Event{
+		Kind:      clienta2a.EventStatus,
+		TaskID:    "task-1",
+		ContextID: "ctx-1",
+		Status: &clienta2a.TaskStatus{
+			State: clienta2a.TaskStateWorking,
+			Message: &clienta2a.Message{ID: "status-1", Parts: []clienta2a.Part{
+				{Kind: clienta2a.PartText, Text: "calling Bash"},
+				{Kind: clienta2a.PartData, Data: map[string]any{"type": "STATUS_TYPE_TOOL_CALL", "toolCall": map[string]any{"id": "bash-1"}}},
+			}},
+		},
+	})
+	if len(events) != 5 || events[1].Kind != DelegationStatus || events[2].Kind != DelegationTextStart ||
+		events[3].Kind != DelegationTextDelta || events[4].Kind != DelegationTextEnd {
+		t.Fatalf("status events = %#v", events)
+	}
+	if events[1].RemoteMessageID != "status-1" || events[1].Text != "calling Bash" || len(events[1].StatusParts) != 2 {
+		t.Fatalf("status payload = %#v", events[1])
+	}
+	data, ok := events[1].StatusParts[1].Data.(map[string]any)
+	if !ok || data["type"] != "STATUS_TYPE_TOOL_CALL" {
+		t.Fatalf("status data = %#v", events[1].StatusParts)
+	}
+}
+
+// TestEventMapperTerminalStatusPreservesDataParts verifies terminal status
+// events keep their structured data before the terminal lifecycle event.
+func TestEventMapperTerminalStatusPreservesDataParts(t *testing.T) {
+	mapper := newEventMapper(DelegationEvent{RunID: "run-1", DelegationID: "del-1", AgentKey: "implement"})
+	events := mapper.Map(clienta2a.Event{
+		Kind:      clienta2a.EventTerminal,
+		TaskID:    "task-1",
+		ContextID: "ctx-1",
+		Status: &clienta2a.TaskStatus{
+			State: clienta2a.TaskStateCompleted,
+			Message: &clienta2a.Message{Parts: []clienta2a.Part{
+				{Kind: clienta2a.PartData, Data: map[string]any{"type": "STATUS_TYPE_TOOL_RESPONSE", "toolResponse": map[string]any{"id": "bash-1"}}},
+			}},
+		},
+	})
+	if len(events) != 2 || events[1].Kind != DelegationStatus {
+		t.Fatalf("terminal status events = %#v", events)
+	}
+	if len(events[1].StatusParts) != 1 {
+		t.Fatalf("terminal status parts = %#v", events[1].StatusParts)
+	}
+}
+
 // TestEventMapperFinalToolArgsEmitsArgsBeforeEnd verifies recovered task snapshots retain complete arguments.
 func TestEventMapperFinalToolArgsEmitsArgsBeforeEnd(t *testing.T) {
 	mapper := newEventMapper(DelegationEvent{RunID: "run-1", DelegationID: "del-1", AgentKey: "implement"})
@@ -138,5 +192,161 @@ func TestEventMapperClosesTextBeforeTerminal(t *testing.T) {
 	}
 	if events[len(events)-2].Kind != DelegationTextEnd || events[len(events)-2].RemoteMessageID != "msg-1" || events[len(events)-1].Kind != DelegationFinished {
 		t.Fatalf("terminal lifecycle = %#v", events)
+	}
+}
+
+func TestAdapterStreamStatusEndIsPriorityEvent(t *testing.T) {
+	mapper := newEventMapper(DelegationEvent{RunID: "run-1", DelegationID: "del-1", AgentKey: "implement"})
+	events := mapper.Map(clienta2a.Event{
+		Kind: clienta2a.EventStatus,
+		Status: &clienta2a.TaskStatus{State: clienta2a.TaskStateWorking, Message: &clienta2a.Message{Parts: []clienta2a.Part{{
+			Kind: clienta2a.PartData,
+			Data: bridgea2a.AdapterStreamEnvelopeV1{
+				Schema: bridgea2a.AdapterStreamSchemaV1,
+				Event:  bridgea2a.AdapterStreamEventV1{Kind: string(agentadaptor.StreamTextEnd), MessageID: "msg-1"},
+			},
+		}}}},
+	})
+	if len(events) != 3 || events[2].Kind != DelegationTextEnd || !isPriorityEvent(events[2]) {
+		t.Fatal("adapter stream text.end should be priority")
+	}
+}
+
+// TestEventMapperAdapterStreamProfile verifies typed decoding, replay deduplication,
+// sequence gap reporting, and profile locking for the built-in stream schema.
+func TestEventMapperAdapterStreamProfile(t *testing.T) {
+	mapper := newEventMapper(DelegationEvent{RunID: "run-1", DelegationID: "del-1", AgentKey: "implement"})
+	eventTime := time.Date(2026, time.July, 21, 10, 30, 0, 0, time.UTC)
+	firstStatus := adapterStreamStatusEvent(bridgea2a.AdapterStreamEventV1{
+		Kind:      string(agentadaptor.StreamTextStart),
+		Sequence:  1,
+		RunID:     "member-run",
+		ThreadID:  "member-thread",
+		TurnID:    "member-turn",
+		MessageID: "msg-1",
+		Role:      string(agentadaptor.RoleUser),
+		Timestamp: eventTime.Format(time.RFC3339Nano),
+	})
+	first := mapper.Map(firstStatus)
+	if len(first) != 3 || first[0].Kind != DelegationStarted || first[1].Kind != DelegationStatus || first[2].Kind != DelegationTextStart {
+		t.Fatalf("first events = %#v", first)
+	}
+	if first[2].Sequence != 1 || first[2].RemoteMessageID != "msg-1" || first[2].Role != string(agentadaptor.RoleUser) ||
+		!first[2].Time.Equal(eventTime) || first[2].Raw["stream_profile"] != bridgea2a.AdapterStreamSchemaV1 ||
+		first[2].Raw["member_run_id"] != "member-run" || first[2].Raw["member_thread_id"] != "member-thread" ||
+		first[2].Raw["member_turn_id"] != "member-turn" {
+		t.Fatalf("first decoded event = %#v", first[2])
+	}
+
+	replay := mapper.Map(firstStatus)
+	if len(replay) != 1 || replay[0].Kind != DelegationStatus {
+		t.Fatalf("replay events = %#v", replay)
+	}
+
+	third := mapper.Map(adapterStreamStatusEvent(bridgea2a.AdapterStreamEventV1{
+		Kind:       string(agentadaptor.StreamToolCallArgs),
+		Sequence:   3,
+		ToolCallID: "bash-1",
+		Delta:      `{"command":"go test ./..."}`,
+	}))
+	if len(third) != 3 || third[0].Kind != DelegationStatus || third[1].Kind != DelegationStreamDropped || third[2].Kind != DelegationToolCallArgs {
+		t.Fatalf("third events = %#v", third)
+	}
+	if third[1].Raw["dropped_count"] != uint64(1) || third[1].Raw["first_missing"] != uint64(2) || third[1].Raw["last_missing"] != uint64(2) {
+		t.Fatalf("gap event = %#v", third[1])
+	}
+	if third[2].Sequence != 3 || third[2].RemoteToolCallID != "bash-1" || third[2].Delta != `{"command":"go test ./..."}` {
+		t.Fatalf("tool args event = %#v", third[2])
+	}
+
+	legacy := mapper.Map(clienta2a.Event{
+		Kind: clienta2a.EventArtifact,
+		Artifact: &clienta2a.Artifact{
+			ID:    "assistant-output",
+			Name:  bridgea2a.ArtifactAssistantOutput,
+			Parts: []clienta2a.Part{{Kind: clienta2a.PartText, Text: "duplicate"}},
+		},
+	})
+	if len(legacy) != 0 {
+		t.Fatalf("mixed legacy events = %#v", legacy)
+	}
+}
+
+type testStatusPartDecoder struct{}
+
+func (testStatusPartDecoder) Profile() string {
+	return "test.status.v1"
+}
+
+func (testStatusPartDecoder) DecodeStatusPart(data any) ([]StatusPartEvent, bool, error) {
+	value, ok := data.(map[string]any)
+	if !ok || value["schema"] != "test.status.v1" {
+		return nil, false, nil
+	}
+	return []StatusPartEvent{{
+		Kind:   DelegationCustom,
+		Name:   "todo.update",
+		Result: value["result"],
+		Raw:    map[string]any{"source": "test"},
+	}}, true, nil
+}
+
+// TestEventMapperInjectedStatusDecoder verifies host-owned schemas are normalized
+// without adding private protocol dependencies to the adapter package.
+func TestEventMapperInjectedStatusDecoder(t *testing.T) {
+	mapper := newEventMapper(
+		DelegationEvent{RunID: "run-1", DelegationID: "del-1", AgentKey: "external"},
+		testStatusPartDecoder{},
+	)
+	events := mapper.Map(clienta2a.Event{
+		Kind:      clienta2a.EventStatus,
+		TaskID:    "task-1",
+		ContextID: "ctx-1",
+		Status: &clienta2a.TaskStatus{
+			State: clienta2a.TaskStateWorking,
+			Message: &clienta2a.Message{ID: "status-1", Parts: []clienta2a.Part{
+				{Kind: clienta2a.PartText, Text: "working"},
+				{Kind: clienta2a.PartData, Data: map[string]any{
+					"schema": "test.status.v1",
+					"result": map[string]any{"items": []any{"test"}},
+				}},
+			}},
+		},
+	})
+	if len(events) != 6 || events[0].Kind != DelegationStarted || events[1].Kind != DelegationStatus ||
+		events[2].Kind != DelegationCustom || events[3].Kind != DelegationTextStart ||
+		events[4].Kind != DelegationTextDelta || events[5].Kind != DelegationTextEnd {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[2].Name != "todo.update" || events[2].Raw["source"] != "test" || events[2].Raw["stream_profile"] != "test.status.v1" {
+		t.Fatalf("custom event = %#v", events[2])
+	}
+	if events[4].Delta != "working" || events[4].RemoteMessageID != "status-1" {
+		t.Fatalf("text event = %#v", events[4])
+	}
+
+	mixed := mapper.Map(adapterStreamStatusEvent(bridgea2a.AdapterStreamEventV1{
+		Kind:      string(agentadaptor.StreamTextContent),
+		Sequence:  1,
+		MessageID: "msg-1",
+		Delta:     "duplicate",
+	}))
+	if len(mixed) != 1 || mixed[0].Kind != DelegationStatus {
+		t.Fatalf("mixed profile events = %#v", mixed)
+	}
+}
+
+func adapterStreamStatusEvent(event bridgea2a.AdapterStreamEventV1) clienta2a.Event {
+	return clienta2a.Event{
+		Kind:      clienta2a.EventStatus,
+		TaskID:    "task-1",
+		ContextID: "ctx-1",
+		Status: &clienta2a.TaskStatus{
+			State: clienta2a.TaskStateWorking,
+			Message: &clienta2a.Message{ID: "status-1", Parts: []clienta2a.Part{{
+				Kind: clienta2a.PartData,
+				Data: bridgea2a.AdapterStreamEnvelopeV1{Schema: bridgea2a.AdapterStreamSchemaV1, Event: event},
+			}}},
+		},
 	}
 }

--- a/pkg/hosttools/a2adelegation/mapping_test.go
+++ b/pkg/hosttools/a2adelegation/mapping_test.go
@@ -180,12 +180,12 @@ func (testStatusPartDecoder) Profile() string {
 	return "test.status.v1"
 }
 
-func (testStatusPartDecoder) DecodeStatusPart(data any) ([]StatusPartEvent, bool, error) {
+func (testStatusPartDecoder) DecodeStatusPart(data any) ([]DelegationEvent, bool, error) {
 	value, ok := data.(map[string]any)
 	if !ok || value["schema"] != "test.status.v1" {
 		return nil, false, nil
 	}
-	return []StatusPartEvent{{
+	return []DelegationEvent{{
 		Kind:   DelegationCustom,
 		Name:   "todo.update",
 		Result: value["result"],
@@ -222,6 +222,10 @@ func TestEventMapperInjectedStatusDecoder(t *testing.T) {
 	}
 	if events[2].Name != "todo.update" || events[2].Raw["source"] != "test" || events[2].Raw["stream_profile"] != "test.status.v1" {
 		t.Fatalf("custom event = %#v", events[2])
+	}
+	if events[2].RunID != "run-1" || events[2].DelegationID != "del-1" || events[2].AgentKey != "external" ||
+		events[2].RemoteTaskID != "task-1" || events[2].RemoteContextID != "ctx-1" || events[2].RemoteMessageID != "status-1" {
+		t.Fatalf("custom event context = %#v", events[2])
 	}
 	if events[4].Delta != "working" || events[4].RemoteMessageID != "status-1" {
 		t.Fatalf("text event = %#v", events[4])

--- a/pkg/hosttools/a2adelegation/mapping_test.go
+++ b/pkg/hosttools/a2adelegation/mapping_test.go
@@ -9,104 +9,25 @@ import (
 	clienta2a "github.com/agent-dance/agent-adaptor/pkg/clients/a2a"
 )
 
-// TestEventMapperAssistantOutputChunksFollowTextLifecycle verifies that A2A artifact chunks become an AG-UI-compatible text lifecycle.
-func TestEventMapperAssistantOutputChunksFollowTextLifecycle(t *testing.T) {
-	mapper := newEventMapper(DelegationEvent{RunID: "run-1", DelegationID: "del-1", AgentKey: "research"})
-	first := mapper.Map(clienta2a.Event{
-		Kind:      clienta2a.EventArtifact,
-		TaskID:    "task-1",
-		ContextID: "ctx-1",
-		Artifact: &clienta2a.Artifact{
-			ID: "assistant-output", Name: bridgea2a.ArtifactAssistantOutput,
-			Parts: []clienta2a.Part{{Kind: clienta2a.PartText, Text: "hello"}},
-		},
-	})
-	if len(first) != 3 {
-		t.Fatalf("first chunk events = %#v", first)
-	}
-	if first[0].Kind != DelegationStarted || first[1].Kind != DelegationTextStart || first[2].Kind != DelegationTextDelta {
-		t.Fatalf("first chunk lifecycle = %#v", first)
-	}
-	if first[1].RemoteMessageID != "assistant-output" || first[2].RemoteMessageID != first[1].RemoteMessageID {
-		t.Fatalf("first chunk message IDs = %#v", first)
-	}
-
-	last := mapper.Map(clienta2a.Event{
-		Kind:      clienta2a.EventArtifact,
-		TaskID:    "task-1",
-		ContextID: "ctx-1",
-		Artifact: &clienta2a.Artifact{
-			ID: "assistant-output", Name: bridgea2a.ArtifactAssistantOutput,
-			Parts: []clienta2a.Part{{Kind: clienta2a.PartText, Text: " world"}},
-		},
-		Append: true, LastChunk: true,
-	})
-	if len(last) != 2 || last[0].Kind != DelegationTextDelta || last[1].Kind != DelegationTextEnd {
-		t.Fatalf("last chunk lifecycle = %#v", last)
-	}
-	if last[0].RemoteMessageID != "assistant-output" || last[1].RemoteMessageID != "assistant-output" {
-		t.Fatalf("last chunk message IDs = %#v", last)
-	}
-}
-
-// TestEventMapperToolArtifactsFollowToolLifecycle verifies bridge tool artifacts are restored to typed host events.
-func TestEventMapperToolArtifactsFollowToolLifecycle(t *testing.T) {
-	mapper := newEventMapper(DelegationEvent{RunID: "run-1", DelegationID: "del-1", AgentKey: "implement"})
-	start := mapper.Map(clienta2a.Event{
-		Kind:      clienta2a.EventArtifact,
-		TaskID:    "task-1",
-		ContextID: "ctx-1",
-		Artifact: &clienta2a.Artifact{
-			ID:   "tool-call-bash-1",
-			Name: "tool-call-bash-1",
-			Parts: []clienta2a.Part{{
-				Kind: clienta2a.PartData,
-				Data: map[string]any{"kind": "tool_call.start", "id": "bash-1", "name": "Bash", "args": map[string]any{"command": "go test ./..."}},
-			}},
-		},
-	})
-	if len(start) != 3 || start[1].Kind != DelegationArtifactCreated || start[2].Kind != DelegationToolCallStart || start[2].RemoteToolCallID != "bash-1" || start[2].ToolName != "Bash" {
-		t.Fatalf("start events = %#v", start)
-	}
-
-	args := mapper.Map(clienta2a.Event{
-		Kind: clienta2a.EventArtifact, TaskID: "task-1", ContextID: "ctx-1",
-		Artifact: &clienta2a.Artifact{ID: "tool-call-bash-1", Name: "tool-call-bash-1", Parts: []clienta2a.Part{{Kind: clienta2a.PartText, Text: " --race"}}},
-	})
-	if len(args) != 2 || args[0].Kind != DelegationArtifactCreated || args[1].Kind != DelegationToolCallArgs || args[1].Delta != " --race" || args[1].RemoteToolCallID != "bash-1" {
-		t.Fatalf("args events = %#v", args)
-	}
-
-	end := mapper.Map(clienta2a.Event{
-		Kind: clienta2a.EventArtifact, TaskID: "task-1", ContextID: "ctx-1", LastChunk: true,
-		Artifact: &clienta2a.Artifact{
-			ID:   "tool-call-bash-1-end",
-			Name: "tool-call-bash-1-end",
-			Parts: []clienta2a.Part{{
-				Kind: clienta2a.PartData,
-				Data: map[string]any{"kind": "tool_call.end", "id": "bash-1"},
-			}},
-		},
-	})
-	if len(end) != 2 || end[0].Kind != DelegationArtifactCreated || end[1].Kind != DelegationToolCallEnd || end[1].RemoteToolCallID != "bash-1" {
-		t.Fatalf("end events = %#v", end)
-	}
-
-	result := mapper.Map(clienta2a.Event{
-		Kind:      clienta2a.EventArtifact,
-		TaskID:    "task-1",
-		ContextID: "ctx-1",
-		Artifact: &clienta2a.Artifact{
-			ID:   "tool-call-bash-1-result",
-			Name: "tool-call-bash-1-result",
-			Parts: []clienta2a.Part{{
-				Kind: clienta2a.PartData,
-				Data: map[string]any{"kind": "tool_call.result", "id": "bash-1", "result": "ok"},
-			}},
-		},
-	})
-	if len(result) != 2 || result[0].Kind != DelegationArtifactCreated || result[1].Kind != DelegationToolCallResult || result[1].RemoteToolCallID != "bash-1" || result[1].Result != "ok" {
-		t.Fatalf("result events = %#v", result)
+// TestEventMapperArtifactsNeverCreateProcessEvents verifies ArtifactUpdate is
+// reserved for final artifacts even when an artifact uses a historical process name.
+func TestEventMapperArtifactsNeverCreateProcessEvents(t *testing.T) {
+	for _, name := range []string{"assistant-output", "tool-call-bash-1", "reasoning", "stream-dropped"} {
+		mapper := newEventMapper(DelegationEvent{RunID: "run-1", DelegationID: "del-1", AgentKey: "implement"})
+		events := mapper.Map(clienta2a.Event{
+			Kind:      clienta2a.EventArtifact,
+			TaskID:    "task-1",
+			ContextID: "ctx-1",
+			Artifact: &clienta2a.Artifact{
+				ID:    name,
+				Name:  name,
+				Parts: []clienta2a.Part{{Kind: clienta2a.PartText, Text: "final result"}},
+			},
+			LastChunk: true,
+		})
+		if len(events) != 2 || events[0].Kind != DelegationStarted || events[1].Kind != DelegationArtifactCreated {
+			t.Fatalf("artifact %q events = %#v", name, events)
+		}
 	}
 }
 
@@ -159,25 +80,6 @@ func TestEventMapperTerminalStatusPreservesDataParts(t *testing.T) {
 	}
 	if len(events[1].StatusParts) != 1 {
 		t.Fatalf("terminal status parts = %#v", events[1].StatusParts)
-	}
-}
-
-// TestEventMapperFinalToolArgsEmitsArgsBeforeEnd verifies recovered task snapshots retain complete arguments.
-func TestEventMapperFinalToolArgsEmitsArgsBeforeEnd(t *testing.T) {
-	mapper := newEventMapper(DelegationEvent{RunID: "run-1", DelegationID: "del-1", AgentKey: "implement"})
-	events := mapper.Map(clienta2a.Event{
-		Kind: clienta2a.EventArtifact, TaskID: "task-1", ContextID: "ctx-1", LastChunk: true,
-		Artifact: &clienta2a.Artifact{
-			ID:   "tool-call-bash-1",
-			Name: "tool-call-bash-1",
-			Parts: []clienta2a.Part{{
-				Kind: clienta2a.PartText,
-				Text: `{"command":"go test ./..."}`,
-			}},
-		},
-	})
-	if len(events) != 4 || events[1].Kind != DelegationArtifactCreated || events[2].Kind != DelegationToolCallArgs || events[3].Kind != DelegationToolCallEnd {
-		t.Fatalf("events = %#v", events)
 	}
 }
 
@@ -259,16 +161,16 @@ func TestEventMapperAdapterStreamProfile(t *testing.T) {
 		t.Fatalf("tool args event = %#v", third[2])
 	}
 
-	legacy := mapper.Map(clienta2a.Event{
+	artifact := mapper.Map(clienta2a.Event{
 		Kind: clienta2a.EventArtifact,
 		Artifact: &clienta2a.Artifact{
 			ID:    "assistant-output",
-			Name:  bridgea2a.ArtifactAssistantOutput,
+			Name:  "assistant-output",
 			Parts: []clienta2a.Part{{Kind: clienta2a.PartText, Text: "duplicate"}},
 		},
 	})
-	if len(legacy) != 0 {
-		t.Fatalf("mixed legacy events = %#v", legacy)
+	if len(artifact) != 1 || artifact[0].Kind != DelegationArtifactCreated {
+		t.Fatalf("artifact events = %#v", artifact)
 	}
 }
 

--- a/pkg/hosttools/a2adelegation/status_decoder.go
+++ b/pkg/hosttools/a2adelegation/status_decoder.go
@@ -1,0 +1,73 @@
+package a2adelegation
+
+import (
+	agentadaptor "github.com/agent-dance/agent-adaptor"
+	bridgea2a "github.com/agent-dance/agent-adaptor/pkg/bridges/a2a"
+)
+
+type adapterStreamStatusDecoder struct{}
+
+func (adapterStreamStatusDecoder) Profile() string {
+	return bridgea2a.AdapterStreamSchemaV1
+}
+
+func (adapterStreamStatusDecoder) DecodeStatusPart(data any) ([]StatusPartEvent, bool, error) {
+	payload, matched, err := bridgea2a.DecodeAdapterStreamStatus(data)
+	if err != nil || !matched {
+		return nil, matched, err
+	}
+	event := StatusPartEvent{
+		Sequence:   payload.Sequence,
+		MessageID:  payload.MessageID,
+		ToolCallID: payload.ToolCallID,
+		Name:       payload.Name,
+		Role:       string(payload.Role),
+		Delta:      payload.Delta,
+		Args:       payload.Args,
+		Result:     payload.Result,
+		Raw:        cloneAnyMap(payload.Raw),
+		Time:       payload.Timestamp,
+	}
+	if event.Raw == nil {
+		event.Raw = map[string]any{}
+	}
+	if payload.RunID != "" {
+		event.Raw["member_run_id"] = payload.RunID
+	}
+	if payload.ThreadID != "" {
+		event.Raw["member_thread_id"] = payload.ThreadID
+	}
+	if payload.TurnID != "" {
+		event.Raw["member_turn_id"] = payload.TurnID
+	}
+	switch payload.Kind {
+	case agentadaptor.StreamTextStart:
+		event.Kind = DelegationTextStart
+	case agentadaptor.StreamTextContent:
+		event.Kind = DelegationTextDelta
+	case agentadaptor.StreamTextEnd:
+		event.Kind = DelegationTextEnd
+	case agentadaptor.StreamReasoningStart:
+		event.Kind = DelegationReasoningStart
+	case agentadaptor.StreamReasoningContent:
+		event.Kind = DelegationReasoningDelta
+	case agentadaptor.StreamReasoningEnd:
+		event.Kind = DelegationReasoningEnd
+	case agentadaptor.StreamToolCallStart:
+		event.Kind = DelegationToolCallStart
+	case agentadaptor.StreamToolCallArgs:
+		event.Kind = DelegationToolCallArgs
+	case agentadaptor.StreamToolCallResult:
+		event.Kind = DelegationToolCallResult
+	case agentadaptor.StreamToolCallEnd:
+		event.Kind = DelegationToolCallEnd
+	case agentadaptor.StreamDropped:
+		event.Kind = DelegationStreamDropped
+	case agentadaptor.StreamHITLRequested, agentadaptor.StreamHITLResolved:
+		event.Kind = DelegationCustom
+		event.Name = string(payload.Kind)
+	default:
+		return nil, true, nil
+	}
+	return []StatusPartEvent{event}, true, nil
+}

--- a/pkg/hosttools/a2adelegation/status_decoder.go
+++ b/pkg/hosttools/a2adelegation/status_decoder.go
@@ -11,22 +11,21 @@ func (adapterStreamStatusDecoder) Profile() string {
 	return bridgea2a.AdapterStreamSchemaV1
 }
 
-func (adapterStreamStatusDecoder) DecodeStatusPart(data any) ([]StatusPartEvent, bool, error) {
+func (adapterStreamStatusDecoder) DecodeStatusPart(data any) ([]DelegationEvent, bool, error) {
 	payload, matched, err := bridgea2a.DecodeAdapterStreamStatus(data)
 	if err != nil || !matched {
 		return nil, matched, err
 	}
-	event := StatusPartEvent{
-		Sequence:   payload.Sequence,
-		MessageID:  payload.MessageID,
-		ToolCallID: payload.ToolCallID,
-		Name:       payload.Name,
-		Role:       string(payload.Role),
-		Delta:      payload.Delta,
-		Args:       payload.Args,
-		Result:     payload.Result,
-		Raw:        cloneAnyMap(payload.Raw),
-		Time:       payload.Timestamp,
+	event := DelegationEvent{
+		Sequence:         payload.Sequence,
+		RemoteMessageID:  payload.MessageID,
+		RemoteToolCallID: payload.ToolCallID,
+		Role:             string(payload.Role),
+		Delta:            payload.Delta,
+		Args:             payload.Args,
+		Result:           payload.Result,
+		Raw:              cloneAnyMap(payload.Raw),
+		Time:             payload.Timestamp,
 	}
 	if event.Raw == nil {
 		event.Raw = map[string]any{}
@@ -55,19 +54,26 @@ func (adapterStreamStatusDecoder) DecodeStatusPart(data any) ([]StatusPartEvent,
 		event.Kind = DelegationReasoningEnd
 	case agentadaptor.StreamToolCallStart:
 		event.Kind = DelegationToolCallStart
+		event.ToolName = payload.Name
 	case agentadaptor.StreamToolCallArgs:
 		event.Kind = DelegationToolCallArgs
+		event.ToolName = payload.Name
 	case agentadaptor.StreamToolCallResult:
 		event.Kind = DelegationToolCallResult
+		event.ToolName = payload.Name
 	case agentadaptor.StreamToolCallEnd:
 		event.Kind = DelegationToolCallEnd
+		event.ToolName = payload.Name
 	case agentadaptor.StreamDropped:
 		event.Kind = DelegationStreamDropped
 	case agentadaptor.StreamHITLRequested, agentadaptor.StreamHITLResolved:
 		event.Kind = DelegationCustom
-		event.Name = string(payload.Kind)
+		event.Name = payload.Name
+		if event.Name == "" {
+			event.Name = string(payload.Kind)
+		}
 	default:
 		return nil, true, nil
 	}
-	return []StatusPartEvent{event}, true, nil
+	return []DelegationEvent{event}, true, nil
 }

--- a/pkg/hosttools/a2adelegation/types.go
+++ b/pkg/hosttools/a2adelegation/types.go
@@ -189,26 +189,12 @@ type RemotePart struct {
 	Metadata  map[string]any     `json:"metadata,omitempty"`
 }
 
-// StatusPartEvent 是业务无关的 Status DataPart 解码结果。
-type StatusPartEvent struct {
-	Kind       DelegationEventKind
-	Sequence   uint64
-	MessageID  string
-	ToolCallID string
-	Name       string
-	Role       string
-	Delta      string
-	Args       any
-	Result     any
-	Raw        map[string]any
-	Time       time.Time
-}
-
-// StatusPartDecoder 把一种 Status DataPart schema 归一化为 DelegationEvent 所需字段。
-// matched=false 表示 data 不属于当前 decoder，允许后续 decoder 继续尝试。
+// StatusPartDecoder 把一种 Status DataPart schema 直接转换为 DelegationEvent。
+// decoder 只填写事件语义字段；当前 delegation 的身份、A2A 上下文和 profile
+// 由 mapper 统一补齐。matched=false 表示 data 不属于当前 decoder，允许后续 decoder 继续尝试。
 type StatusPartDecoder interface {
 	Profile() string
-	DecodeStatusPart(data any) (events []StatusPartEvent, matched bool, err error)
+	DecodeStatusPart(data any) (events []DelegationEvent, matched bool, err error)
 }
 
 type DelegationEvent struct {

--- a/pkg/hosttools/a2adelegation/types.go
+++ b/pkg/hosttools/a2adelegation/types.go
@@ -28,11 +28,16 @@ const (
 	DelegationTextStart       DelegationEventKind = "subagent.text.start"
 	DelegationTextDelta       DelegationEventKind = "subagent.text.delta"
 	DelegationTextEnd         DelegationEventKind = "subagent.text.end"
+	DelegationReasoningStart  DelegationEventKind = "subagent.reasoning.start"
+	DelegationReasoningDelta  DelegationEventKind = "subagent.reasoning.delta"
+	DelegationReasoningEnd    DelegationEventKind = "subagent.reasoning.end"
 	DelegationToolCallStart   DelegationEventKind = "subagent.tool_call.start"
 	DelegationToolCallArgs    DelegationEventKind = "subagent.tool_call.args"
 	DelegationToolCallResult  DelegationEventKind = "subagent.tool_call.result"
 	DelegationToolCallEnd     DelegationEventKind = "subagent.tool_call.end"
 	DelegationArtifactCreated DelegationEventKind = "subagent.artifact"
+	DelegationCustom          DelegationEventKind = "subagent.custom"
+	DelegationStreamDropped   DelegationEventKind = "subagent.stream.dropped"
 	DelegationInputRequired   DelegationEventKind = "subagent.input_required"
 	DelegationFinished        DelegationEventKind = "subagent.finished"
 	DelegationFailed          DelegationEventKind = "subagent.failed"
@@ -184,6 +189,28 @@ type RemotePart struct {
 	Metadata  map[string]any     `json:"metadata,omitempty"`
 }
 
+// StatusPartEvent 是业务无关的 Status DataPart 解码结果。
+type StatusPartEvent struct {
+	Kind       DelegationEventKind
+	Sequence   uint64
+	MessageID  string
+	ToolCallID string
+	Name       string
+	Role       string
+	Delta      string
+	Args       any
+	Result     any
+	Raw        map[string]any
+	Time       time.Time
+}
+
+// StatusPartDecoder 把一种 Status DataPart schema 归一化为 DelegationEvent 所需字段。
+// matched=false 表示 data 不属于当前 decoder，允许后续 decoder 继续尝试。
+type StatusPartDecoder interface {
+	Profile() string
+	DecodeStatusPart(data any) (events []StatusPartEvent, matched bool, err error)
+}
+
 type DelegationEvent struct {
 	RunID            string
 	ParentToolCallID string
@@ -197,8 +224,11 @@ type DelegationEvent struct {
 	RemoteMessageID  string
 	RemoteArtifactID string
 	RemoteToolCallID string
+	Sequence         uint64
 
 	Kind     DelegationEventKind
+	Name     string
+	Role     string
 	Delta    string
 	Text     string
 	ToolName string
@@ -206,9 +236,12 @@ type DelegationEvent struct {
 	Result   any
 	Artifact *DelegationArtifact
 	Status   string
-	Error    *DelegationError
-	Raw      map[string]any
-	Time     time.Time
+	// StatusParts preserves the remote A2A status message parts for hosts that
+	// consume structured status data.
+	StatusParts []RemotePart
+	Error       *DelegationError
+	Raw         map[string]any
+	Time        time.Time
 }
 
 type DelegationResult struct {


### PR DESCRIPTION
## 这次改的是什么

Agent 执行时会不断产生正文、思考过程、工具参数和工具结果。这些是执行过程，需要实时展示；方案结果、文件和最终运行摘要才是最终业务产物。

这次把两类数据彻底分开：

| 内容 | A2A 事件 |
| --- | --- |
| 正文、思考过程、工具调用、工具参数、工具结果、消息丢失提示 | `TaskStatusUpdateEvent` 的 `DataPart` |
| 最终运行摘要和自定义最终文件 | `TaskArtifactUpdateEvent` |

`ArtifactUpdate` 不再用来传递正文或工具执行过程。

## 删除了什么

以前适配器提供 `StreamWireMode`，调用方可以选择把过程消息发成 Artifact。旧方式使用下面的 Artifact 名称：

- `assistant-output`：正文
- `reasoning`：思考过程
- `tool-call-*`：工具调用和结果
- `stream-dropped`：消息丢失

这次删除：

- `StreamWireMode`
- `StreamWireLegacyArtifact`
- `StreamWireStatusData`
- `ServerOptions.StreamWire`
- 发送和接收旧过程 Artifact 的代码

现在调用方不能再选择旧方式。适配器固定把 `StreamPayload` 编码为 `adapter.stream.v1`，放进 `TaskStatusUpdateEvent` 的 `DataPart`。

如果接收端收到名字仍然是 `assistant-output`、`reasoning`、`tool-call-*` 或 `stream-dropped` 的 Artifact，它只会得到 `DelegationArtifactCreated`，不会再得到正文、思考过程或工具调用事件。

## 内置格式的内容

`adapter.stream.v1` 支持：

- `text.start`、`text.content`、`text.end`
- `reasoning.start`、`reasoning.content`、`reasoning.end`
- `tool_call.start`、`tool_call.args`、`tool_call.result`、`tool_call.end`
- HITL 过程消息和 `stream.dropped`

每条消息可以保留运行编号、线程编号、回合编号、消息编号、工具调用编号、角色、原始时间和成员序号。正文、工具参数和工具结果会按现有规则处理敏感信息和大小限制。

## 怎么接入自定义 DataPart 格式

当前支持的是 **A2A 里面自定义 `DataPart` 格式**，不是任意网络协议。远端请求、响应和流式连接仍然走 A2A。

宿主可以实现下面的接口：

```go
type StatusPartDecoder interface {
    Profile() string
    DecodeStatusPart(data any) (events []DelegationEvent, matched bool, err error)
}
```

接入步骤：

1. 给格式定义稳定、带版本的 profile，例如 `vendor.progress.v1`。
2. 在 `DecodeStatusPart` 中检查自己的 `schema`、`type` 或 Proto 字段。
3. 不属于自己的数据返回 `matched=false`，让下一个 decoder 继续判断。
4. 直接返回 `DelegationEvent`，只填写事件语义字段：正文使用 `Kind` 和 `Delta`，工具使用 `RemoteToolCallID`、`ToolName`、`Args`、`Result`，页面专用消息使用 `DelegationCustom`、`Name` 和 `Raw`。
5. 属于自己但格式错误时返回 `matched=true` 和 error，框架会生成 `subagent.stream.dropped`，不会假装消息完整。
6. 创建 `Delegator` 时注册：

```go
a2adelegation.NewDelegator(
    registry,
    bus,
    a2adelegation.WithStatusPartDecoder(VendorProgressDecoder{}),
)
```

Decoder 不用填写 `RunID`、`DelegationID`、成员名称、远端 task/context/message、profile 和默认时间。`eventMapper.completeStatusDelegationEvent` 会统一补齐这些字段。

多个 decoder 可以同时注册。内置 `adapter.stream.v1` decoder 总会先尝试；自定义 decoder 按注册顺序尝试。

同一次成员委派只会锁定一个 `Profile()`：第一个成功识别的格式决定后续过程消息格式，不同 profile 的数据不会再投影到页面。这样可以避免同一成员同时发两套消息造成重复展示。

同一条 DataPart 会按 `profile + messageID + 数据摘要` 去重；有 sequence 的格式会检查缺号并生成 `subagent.stream.dropped`。

## 后续扩展方式

- 新增同一宿主的 DataPart schema：新增一个 decoder 并注册，不需要改 `agent-adaptor` 私有依赖。
- 新增一种页面语义：先使用 `DelegationCustom` 和稳定事件名；只有需要通用生命周期或专门 UI 组件时才新增 `DelegationEventKind`。
- 新增非 A2A 的网络传输：需要新增独立 client/transport 适配层，不能只增加 `StatusPartDecoder`。

## 最终产物

最终运行摘要和自定义结果文件仍通过 `ArtifactUpdate` 返回，相关协议没有变化。

## 验证

执行过：

- `go test ./...`
- `go test -race ./pkg/hosttools/a2adelegation/... ./pkg/bridges/a2a/...`

测试覆盖：

- `adapter.stream.v1` 编码和解码
- 自定义 decoder 直接返回 `DelegationEvent`
- 公共 helper 补齐当前委派和远端 A2A 上下文
- profile 锁定、重复消息去重、序号缺口
- 队列满时的 `subagent.stream.dropped`
- 敏感信息和数据大小限制
- 正文、思考过程、工具调用生命周期
- 旧过程 Artifact 不会生成正文或工具过程
