### PR TITLE
Fix legacy closed-listener error classification

### DIFF
--- a/internal/toolruntime/runtime.go
+++ b/internal/toolruntime/runtime.go
@@ -730,7 +730,17 @@ func (g *gateway) stopAdmission() error {
 }
 
 func isClosedNetworkError(err error) bool {
-	return errors.Is(err, net.ErrClosed) || (err != nil && err.Error() == net.ErrClosed.Error())
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	// Older poll implementations expose an unwrap chain but use a distinct
+	// sentinel value with net.ErrClosed's canonical text.
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		if current.Error() == net.ErrClosed.Error() {
+			return true
+		}
+	}
+	return false
 }
 
 func (g *gateway) shutdownAndDrain(registration *registration, timeout time.Duration) error {

--- a/internal/toolruntime/runtime_test.go
+++ b/internal/toolruntime/runtime_test.go
@@ -104,6 +104,24 @@ func TestGatewaySharesEndpointAndRoutesBearerToImmutableCatalog(t *testing.T) {
 	}
 }
 
+func TestClosedNetworkErrorRecognizesLegacyWrappedListenerError(t *testing.T) {
+	legacy := &net.OpError{
+		Op:   "close",
+		Net:  "tcp4",
+		Addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 43210},
+		Err:  errors.New(net.ErrClosed.Error()),
+	}
+	if errors.Is(legacy, net.ErrClosed) {
+		t.Fatal("fixture unexpectedly implements errors.Is; it no longer covers the legacy path")
+	}
+	if !isClosedNetworkError(legacy) {
+		t.Fatalf("legacy closed-listener error was not recognized: %v", legacy)
+	}
+	if isClosedNetworkError(errors.New("permission denied")) {
+		t.Fatal("unrelated listener error was classified as already closed")
+	}
+}
+
 func TestToolFailuresAreSanitizedAndDeadlinesPropagate(t *testing.T) {
 	config := testGatewayConfig()
 	config.handlerTimeout = 75 * time.Millisecond


### PR DESCRIPTION
## Summary

- recognize legacy wrapped listener-close errors that carry the canonical `net.ErrClosed` text but do not participate in `errors.Is`
- keep unrelated listener errors observable
- add a regression fixture using the exact wrapped error shape observed in the post-merge Linux race job

## Validation

- `go test -count=100 ./internal/toolruntime`
- `go test -count=100 . -run 'TestToolCatalogResumesThreadAcrossAgentRestartAndEphemeralPortChange|TestWithToolsUsesStableExistingRuntimeMCPPipeline'`
- `go vet ./...`
- `git diff --check`

Follow-up to #15.
