### PR TITLE
Normalize hosted Tool gateway shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project are documented in this file.
 - Preserved the concrete `ProfilePayload.Fingerprint` across Thread execution;
   only the separate session compatibility guard now normalizes Agent-owned
   ephemeral endpoint and credential-carrier allocations.
+- Normalized already-closed listener errors across both Tool gateway admission
+  fencing and HTTP shutdown so retry cleanup remains idempotent on Linux.
 
 ## [1.1.0] - 2026-07-31
 

--- a/internal/toolruntime/runtime.go
+++ b/internal/toolruntime/runtime.go
@@ -768,12 +768,15 @@ func (g *gateway) shutdownAndDrain(registration *registration, timeout time.Dura
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	err := g.server.Shutdown(shutdownCtx)
 	cancel()
-	if errors.Is(err, http.ErrServerClosed) {
+	if errors.Is(err, http.ErrServerClosed) || isClosedNetworkError(err) {
 		err = nil
 	}
 	if err != nil {
 		closeErr := g.server.Close()
-		if closeErr != nil && !errors.Is(closeErr, http.ErrServerClosed) {
+		if errors.Is(closeErr, http.ErrServerClosed) || isClosedNetworkError(closeErr) {
+			closeErr = nil
+		}
+		if closeErr != nil {
 			err = errors.Join(err, closeErr)
 		}
 		// A bounded graceful-shutdown deadline is an internal transition to

--- a/internal/toolruntime/runtime_test.go
+++ b/internal/toolruntime/runtime_test.go
@@ -138,6 +138,37 @@ func TestClosedNetworkErrorRecognizesLegacyWrappedListenerError(t *testing.T) {
 	}
 }
 
+func TestRuntimeCloseNormalizesPreclosedGatewayListener(t *testing.T) {
+	manager := newGatewayManager(testGatewayConfig())
+	runtime := newTestRuntime(t, manager, "echo", func(_ context.Context, input testInput) (testOutput, error) {
+		return testOutput{Value: input.Value}, nil
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := runtime.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	manager.mu.Lock()
+	gateway := manager.instance
+	manager.mu.Unlock()
+	if gateway == nil {
+		t.Fatal("Start did not publish a gateway")
+	}
+	if err := gateway.listener.Close(); err != nil {
+		t.Fatalf("preclose listener: %v", err)
+	}
+	select {
+	case <-gateway.serveDone:
+	case <-ctx.Done():
+		t.Fatalf("Serve did not observe preclosed listener: %v", ctx.Err())
+	}
+
+	if err := runtime.Close(ctx); err != nil {
+		t.Fatalf("Close after listener preclose: %v", err)
+	}
+}
+
 func TestToolFailuresAreSanitizedAndDeadlinesPropagate(t *testing.T) {
 	config := testGatewayConfig()
 	config.handlerTimeout = 75 * time.Millisecond


### PR DESCRIPTION
## Summary

Follow-up release-gate fix for PR #17.

The exact merged commit Linux race run exposed a real idempotency gap: the Tool gateway admission fence closes the listener first, then `http.Server.Shutdown` can return a wrapped already-closed network error while closing the same listener again. That safe terminal state was incorrectly reported as `Agent.Close` failure.

- normalize `net.ErrClosed` from both graceful Shutdown and forced Close
- add a deterministic test that precloses the gateway listener before `Runtime.Close`
- record the fix in the v1.1.1 changelog

## Verification

- new runtime shutdown test under race, 100 repetitions
- hosted Tool profile/Agent Close regression under race, 100 repetitions
- `go test -count=1 ./...`
- `go vet ./...`
- `go test -race -count=1 ./...`

This PR must merge and main CI must be green before the v1.1.1 tag is created.