### PR TITLE
fix(codex): ignore restored stale turn usage on resume

### DIFF
--- a/codex/appserver/appserver_test.go
+++ b/codex/appserver/appserver_test.go
@@ -570,6 +570,51 @@ func TestRunStateQueuesNotificationsUntilRPCIdentitiesAreKnown(t *testing.T) {
 	}
 }
 
+func TestRunStateIgnoresRestoredTokenUsageFromPreviousTurn(t *testing.T) {
+	t.Parallel()
+	sink := &recordingSink{}
+	state := newRunState("run-resumed-usage", sink)
+
+	// Codex replays this persisted notification immediately after
+	// thread/resume, before turn/start returns the next turn identity.
+	state.onNotification(NotifyThreadTokenUsageUpdated, json.RawMessage(`{"threadId":"thread-resumed","turnId":"turn-previous","tokenUsage":{"last":{"inputTokens":1,"outputTokens":2,"cachedInputTokens":0,"reasoningOutputTokens":0},"total":{"inputTokens":101,"outputTokens":202,"cachedInputTokens":3,"reasoningOutputTokens":0}}}`))
+	state.setThread("thread-resumed")
+	state.setTurn("turn-current")
+
+	if err := state.protocolError(); err != nil {
+		t.Fatalf("restored previous-turn usage caused a protocol error: %v", err)
+	}
+	if result := state.snapshot(Options{}, "thread-resumed", "", "", 0, "", false); result.Usage != nil {
+		t.Fatalf("restored previous-turn usage contaminated current run: %#v", result.Usage)
+	}
+	for _, payload := range sink.streams {
+		if payload.Name == NotifyThreadTokenUsageUpdated {
+			t.Fatalf("restored previous-turn usage escaped to the current public stream: %+v", payload)
+		}
+	}
+
+	state.onNotification(NotifyThreadTokenUsageUpdated, json.RawMessage(`{"threadId":"thread-resumed","turnId":"turn-current","tokenUsage":{"last":{"inputTokens":4,"outputTokens":5,"cachedInputTokens":1,"reasoningOutputTokens":0},"total":{"inputTokens":14,"outputTokens":25,"cachedInputTokens":6,"reasoningOutputTokens":0}}}`))
+	state.onNotification(NotifyTurnCompleted, json.RawMessage(`{"threadId":"thread-resumed","turn":{"id":"turn-current","status":"completed"}}`))
+	result := state.snapshot(Options{}, "thread-resumed", "", "", 0, "", false)
+	if result.Usage == nil || result.Usage.InputTokens != 14 || result.Usage.OutputTokens != 25 || result.Usage.CachedInputTokens != 6 {
+		t.Fatalf("current-turn usage = %#v", result.Usage)
+	}
+	if result.Checkpoint == nil || !result.Checkpoint.Valid {
+		t.Fatalf("resumed run checkpoint = %#v", result.Checkpoint)
+	}
+}
+
+func TestRunStateStillRejectsTokenUsageFromAnotherThread(t *testing.T) {
+	t.Parallel()
+	state := newRunState("run-wrong-thread-usage", &recordingSink{})
+	state.setThread("thread-expected")
+	state.setTurn("turn-current")
+	state.onNotification(NotifyThreadTokenUsageUpdated, json.RawMessage(`{"threadId":"thread-wrong","turnId":"turn-previous","tokenUsage":{"last":{"inputTokens":1,"outputTokens":1,"cachedInputTokens":0,"reasoningOutputTokens":0},"total":{"inputTokens":1,"outputTokens":1,"cachedInputTokens":0,"reasoningOutputTokens":0}}}`))
+	if err := state.protocolError(); err == nil || !strings.Contains(err.Error(), "belongs to thread") {
+		t.Fatalf("protocol error = %v, want wrong-thread rejection", err)
+	}
+}
+
 func TestRunStateErrorNotificationIsNotTerminal(t *testing.T) {
 	t.Parallel()
 	state := newRunState("run-error", &recordingSink{})
@@ -885,6 +930,30 @@ func TestRunResumeRejectsProviderThreadIdentityChange(t *testing.T) {
 	}
 }
 
+func TestRunResumeAcceptsRestoredPreviousTurnTokenUsage(t *testing.T) {
+	fake := buildFakeAppserver(t)
+	sink := &recordingSink{}
+	result, err := Run(context.Background(), Options{
+		Command:        fake,
+		Env:            []driver.EnvBinding{{Name: "FAKE_APPSERVER_SCENARIO", Value: "resume-stale-token-usage"}},
+		ResumeThreadID: "thread-fake",
+	}, sink)
+	if err != nil {
+		t.Fatalf("Run resume with restored previous-turn usage: %v", err)
+	}
+	if result.Output != "hello from fake" || result.Checkpoint == nil || !result.Checkpoint.Valid {
+		t.Fatalf("resume result = %#v", result)
+	}
+	if result.Usage == nil || result.Usage.InputTokens != 7 || result.Usage.OutputTokens != 11 {
+		t.Fatalf("resume usage = %#v, want current turn/completed usage", result.Usage)
+	}
+	for _, payload := range sink.streams {
+		if payload.Name == NotifyThreadTokenUsageUpdated {
+			t.Fatalf("restored previous-turn usage escaped to current stream: %+v", payload)
+		}
+	}
+}
+
 func TestRunRejectsNotificationOutsideExpectedThreadAndTurn(t *testing.T) {
 	fake := buildFakeAppserver(t)
 	sink := &recordingSink{}
@@ -1050,6 +1119,9 @@ func main() {
 			}
 			currentThread = "thread-fake"
 			respond(req.ID, "{\"thread\":{\"id\":\"thread-fake\"}}")
+			if req.Method == "thread/resume" && scenario == "resume-stale-token-usage" {
+				write("{\"method\":\"thread/tokenUsage/updated\",\"params\":{\"threadId\":\"thread-fake\",\"turnId\":\"turn-previous\",\"tokenUsage\":{\"last\":{\"inputTokens\":1,\"outputTokens\":2,\"cachedInputTokens\":0,\"reasoningOutputTokens\":0},\"total\":{\"inputTokens\":101,\"outputTokens\":202,\"cachedInputTokens\":3,\"reasoningOutputTokens\":0}}}}")
+			}
 		case "thread/fork":
 			if scenario == "whitespace-thread-fork" {
 				respond(req.ID, "{\"thread\":{\"id\":\" \"}}")
@@ -1102,7 +1174,7 @@ func main() {
 			if status == "scope-mismatch" {
 				status = "completed"
 			}
-			if status == "success" || status == "" || status == "structured-valid" || status == "nonzero-after-terminal" || status == "malformed-item-live" {
+			if status == "success" || status == "" || status == "structured-valid" || status == "nonzero-after-terminal" || status == "malformed-item-live" || status == "resume-stale-token-usage" {
 				status = "completed"
 			}
 			errorField := ""

--- a/codex/appserver/run.go
+++ b/codex/appserver/run.go
@@ -414,8 +414,8 @@ func (s *runState) handleNotificationLocked(method string, params json.RawMessag
 	}
 	s.mu.Unlock()
 
-	deferred, err := s.bindNotificationScopeLocked(method, params)
-	if deferred {
+	deferred, ignored, err := s.bindNotificationScopeLocked(method, params)
+	if deferred || ignored {
 		return
 	}
 	if err != nil {
@@ -515,10 +515,10 @@ func (s *runState) flushPendingNotificationsLocked() {
 	}
 }
 
-func (s *runState) bindNotificationScopeLocked(method string, params json.RawMessage) (bool, error) {
+func (s *runState) bindNotificationScopeLocked(method string, params json.RawMessage) (deferred, ignored bool, err error) {
 	threadID, turnID, scoped, turnScoped, err := appServerNotificationScope(method, params)
 	if err != nil || !scoped {
-		return false, err
+		return false, false, err
 	}
 
 	s.mu.Lock()
@@ -528,15 +528,26 @@ func (s *runState) bindNotificationScopeLocked(method string, params json.RawMes
 			method: method,
 			params: append(json.RawMessage(nil), params...),
 		})
-		return true, nil
+		return true, false, nil
 	}
 	if threadID != s.threadID {
-		return false, fmt.Errorf("codex app-server notification %s belongs to thread %q, want %q", method, threadID, s.threadID)
+		return false, false, fmt.Errorf("codex app-server notification %s belongs to thread %q, want %q", method, threadID, s.threadID)
 	}
 	if turnScoped && turnID != s.turnID {
-		return false, fmt.Errorf("codex app-server notification %s belongs to turn %q, want %q", method, turnID, s.turnID)
+		// thread/resume replays the persisted token-usage snapshot before the
+		// next turn starts. It is correctly scoped to this thread but retains
+		// the previous turn ID, so it must not contaminate the new run's usage
+		// or trip the strict scope fence. All other cross-turn notifications
+		// remain protocol errors.
+		if method == NotifyThreadTokenUsageUpdated {
+			if err := validateAppServerNotification(method, params); err != nil {
+				return false, false, fmt.Errorf("decode %s: %w", method, err)
+			}
+			return false, true, nil
+		}
+		return false, false, fmt.Errorf("codex app-server notification %s belongs to turn %q, want %q", method, turnID, s.turnID)
 	}
-	return false, nil
+	return false, false, nil
 }
 
 func appServerNotificationScope(method string, params json.RawMessage) (threadID, turnID string, scoped, turnScoped bool, err error) {


### PR DESCRIPTION
## Summary

- tolerate the persisted `thread/tokenUsage/updated` replay emitted by Codex immediately after `thread/resume`
- ignore that previous-turn usage only when it belongs to the exact resumed thread
- keep all other cross-turn notifications and every cross-thread notification fail-closed
- prevent restored usage from contaminating the current run's usage or public event stream

## Why

Codex app-server replays persisted token usage after `thread/resume`, before the next `turn/start` identity is available. The notification retains the previous turn ID. `runState` queues it while identities are unknown, then currently rejects it after the new turn ID is bound. This terminates the resumed run before provider output and causes the newly started Codex turn to be interrupted during shutdown.

A real `Agent -> Close -> resume-only Agent` reproduction failed deterministically with:

```
thread/tokenUsage/updated belongs to turn <previous>, want <current>
```

## Safety boundary

The exception is intentionally narrow:

- the thread ID must still match exactly
- the notification must decode as a valid typed token-usage notification
- only `thread/tokenUsage/updated` can be ignored on a turn mismatch
- the restored usage is not cached, translated, or emitted
- wrong-thread usage and wrong-turn item/terminal notifications remain protocol errors

## Tests

- state-machine reproduction with the notification arriving before RPC identities are known
- process-level fake app-server resume reproduction
- current-turn usage remains authoritative
- wrong-thread usage remains rejected
- targeted tests `-count=50` / process reproduction `-count=20`
- `go test ./...`
- `go vet ./...`
- `git diff --check`