### PR TITLE
feat: add exact per-tool MCP approval policies

### DIFF
--- a/adaptertest/testdata/driver_api.golden
+++ b/adaptertest/testdata/driver_api.golden
@@ -601,6 +601,7 @@ type MCPCapability struct {
 	Stdio bool
 	HTTP bool
 	SSE bool
+	ToolApprovals bool
 }
 
 type MCPPayload struct {
@@ -620,6 +621,17 @@ type MCPServerSpec struct {
 	BearerTokenEnvVar string
 	Required bool
 	RequiredReason string
+	Tools map[string]MCPToolPolicy
+}
+
+const MCPToolApprovalApprove MCPToolApprovalMode = "approve"
+
+type MCPToolApprovalMode string
+
+const MCPToolApprovalPrompt MCPToolApprovalMode = "prompt"
+
+type MCPToolPolicy struct {
+	ApprovalMode MCPToolApprovalMode
 }
 
 type MCPTransport string

--- a/codex/driver.go
+++ b/codex/driver.go
@@ -53,7 +53,7 @@ func (adapter) Descriptor() driver.Descriptor {
 		ConfigSchema: &driver.ConfigSchema{Fields: fields},
 		Sessions:     driver.SessionCapability{SupportsResume: true},
 		Skills:       driver.SkillCapability{Supported: true, Mode: driver.SkillSyncPersistent},
-		MCP:          driver.MCPCapability{Supported: true, Stdio: true, HTTP: true},
+		MCP:          driver.MCPCapability{Supported: true, Stdio: true, HTTP: true, ToolApprovals: true},
 		Instructions: driver.InstructionsCapability{Supported: true},
 		Workspace:    driver.WorkspaceCapability{Supported: true},
 		Process:      driver.ProcessCapability{Persistent: true},

--- a/driver/mcp.go
+++ b/driver/mcp.go
@@ -5,6 +5,10 @@ package driver
 // CLI configuration only when their descriptor advertises support.
 type MCPTransport string
 
+// MCPToolApprovalMode is the closed, provider-neutral approval policy for one
+// exact tool on one exact MCP server.
+type MCPToolApprovalMode string
+
 const (
 	// MCPTransportStdio starts a local command and speaks MCP over stdio.
 	MCPTransportStdio MCPTransport = "stdio"
@@ -13,6 +17,19 @@ const (
 	// MCPTransportSSE connects to an SSE-based MCP endpoint.
 	MCPTransportSSE MCPTransport = "sse"
 )
+
+const (
+	// MCPToolApprovalPrompt keeps the provider's approval prompt for this tool.
+	MCPToolApprovalPrompt MCPToolApprovalMode = "prompt"
+	// MCPToolApprovalApprove authorizes this exact tool without an additional
+	// provider approval prompt. It does not affect other tools or operations.
+	MCPToolApprovalApprove MCPToolApprovalMode = "approve"
+)
+
+// MCPToolPolicy configures one exact MCP tool.
+type MCPToolPolicy struct {
+	ApprovalMode MCPToolApprovalMode
+}
 
 // MCPServerSpec is one host-declared MCP server. For stdio servers, Command
 // and Args describe the process to launch. For HTTP/SSE servers, URL, Headers,
@@ -29,6 +46,9 @@ type MCPServerSpec struct {
 	BearerTokenEnvVar string
 	Required          bool
 	RequiredReason    string
+	// Tools contains exact tool-name overrides. Drivers must never interpret
+	// keys as prefixes, globs, or a server-wide default.
+	Tools map[string]MCPToolPolicy
 }
 
 // MCPPayload is the normalized driver-facing MCP configuration after
@@ -42,8 +62,9 @@ type MCPPayload struct {
 // MCPCapability describes which MCP transports a driver supports. The SDK
 // validates host-provided MCPConfig against this before invoking the driver.
 type MCPCapability struct {
-	Supported bool
-	Stdio     bool
-	HTTP      bool
-	SSE       bool
+	Supported     bool
+	Stdio         bool
+	HTTP          bool
+	SSE           bool
+	ToolApprovals bool
 }

--- a/internal/engine/driver_types.go
+++ b/internal/engine/driver_types.go
@@ -341,16 +341,20 @@ const (
 // --- MCP ------------------------------------------------------------------
 
 type (
-	MCPTransport  = driver.MCPTransport
-	MCPServerSpec = driver.MCPServerSpec
-	MCPPayload    = driver.MCPPayload
-	MCPCapability = driver.MCPCapability
+	MCPTransport        = driver.MCPTransport
+	MCPServerSpec       = driver.MCPServerSpec
+	MCPToolApprovalMode = driver.MCPToolApprovalMode
+	MCPToolPolicy       = driver.MCPToolPolicy
+	MCPPayload          = driver.MCPPayload
+	MCPCapability       = driver.MCPCapability
 )
 
 const (
-	MCPTransportStdio = driver.MCPTransportStdio
-	MCPTransportHTTP  = driver.MCPTransportHTTP
-	MCPTransportSSE   = driver.MCPTransportSSE
+	MCPTransportStdio      = driver.MCPTransportStdio
+	MCPTransportHTTP       = driver.MCPTransportHTTP
+	MCPTransportSSE        = driver.MCPTransportSSE
+	MCPToolApprovalPrompt  = driver.MCPToolApprovalPrompt
+	MCPToolApprovalApprove = driver.MCPToolApprovalApprove
 )
 
 // --- HITL decisions -------------------------------------------------------

--- a/internal/engine/mcp.go
+++ b/internal/engine/mcp.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+
+	"github.com/agent-dance/agent-adaptor/driver"
 )
 
 // MCPConfig is the Agent-level or per-run collection of MCP servers. Per-run
@@ -42,6 +44,7 @@ func cloneMCPServerSpec(value MCPServerSpec) MCPServerSpec {
 		BearerTokenEnvVar: value.BearerTokenEnvVar,
 		Required:          value.Required,
 		RequiredReason:    value.RequiredReason,
+		Tools:             cloneMCPToolPolicies(value.Tools),
 	}
 }
 
@@ -51,6 +54,17 @@ func cloneMCPServerSpecPtr(value *MCPServerSpec) *MCPServerSpec {
 	}
 	spec := cloneMCPServerSpec(*value)
 	return &spec
+}
+
+func cloneMCPToolPolicies(values map[string]driver.MCPToolPolicy) map[string]driver.MCPToolPolicy {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]driver.MCPToolPolicy, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
 }
 
 func cloneMCPPayload(payload MCPPayload) MCPPayload {
@@ -158,7 +172,7 @@ func prepareMCPPayload(cfg MCPConfig, caps MCPCapability) (MCPPayload, error) {
 	normalized := make([]MCPServerSpec, 0, len(cfg.Servers))
 	seen := map[string]struct{}{}
 	for _, server := range cfg.Servers {
-		spec, err := normalizeMCPServerSpec(server)
+		spec, err := normalizeMCPServerSpec(server, caps)
 		if err != nil {
 			return MCPPayload{}, err
 		}
@@ -182,7 +196,7 @@ func prepareMCPPayload(cfg MCPConfig, caps MCPCapability) (MCPPayload, error) {
 	}, nil
 }
 
-func normalizeMCPServerSpec(server MCPServerSpec) (MCPServerSpec, error) {
+func normalizeMCPServerSpec(server MCPServerSpec, caps MCPCapability) (MCPServerSpec, error) {
 	key := strings.TrimSpace(server.Key)
 	if key == "" {
 		return MCPServerSpec{}, fmt.Errorf("%w: MCP server key is required", ErrInvalidMCPConfig)
@@ -199,6 +213,29 @@ func normalizeMCPServerSpec(server MCPServerSpec) (MCPServerSpec, error) {
 		BearerTokenEnvVar: strings.TrimSpace(server.BearerTokenEnvVar),
 		Required:          server.Required,
 		RequiredReason:    strings.TrimSpace(server.RequiredReason),
+		Tools:             make(map[string]driver.MCPToolPolicy, len(server.Tools)),
+	}
+	if len(server.Tools) > 0 && !caps.ToolApprovals {
+		return MCPServerSpec{}, fmt.Errorf("%w: adapter does not support exact-tool MCP approval policy", ErrMCPUnsupported)
+	}
+	for rawName, policy := range server.Tools {
+		name := strings.TrimSpace(rawName)
+		if name == "" {
+			return MCPServerSpec{}, fmt.Errorf("%w: MCP server %q has an empty tool policy name", ErrInvalidMCPConfig, key)
+		}
+		mode := MCPToolApprovalMode(strings.ToLower(strings.TrimSpace(string(policy.ApprovalMode))))
+		switch mode {
+		case MCPToolApprovalPrompt, MCPToolApprovalApprove:
+		default:
+			return MCPServerSpec{}, fmt.Errorf("%w: MCP server %q tool %q has unsupported approval mode %q", ErrInvalidMCPConfig, key, name, policy.ApprovalMode)
+		}
+		if _, exists := spec.Tools[name]; exists {
+			return MCPServerSpec{}, fmt.Errorf("%w: MCP server %q has duplicate normalized tool policy %q", ErrInvalidMCPConfig, key, name)
+		}
+		spec.Tools[name] = driver.MCPToolPolicy{ApprovalMode: mode}
+	}
+	if len(spec.Tools) == 0 {
+		spec.Tools = nil
 	}
 
 	switch spec.Transport {

--- a/internal/engine/mcp_runtime_test.go
+++ b/internal/engine/mcp_runtime_test.go
@@ -2,7 +2,10 @@ package engine
 
 import (
 	"errors"
+	"reflect"
 	"testing"
+
+	"github.com/agent-dance/agent-adaptor/driver"
 )
 
 func TestRuntimeServiceMetadataDoesNotDeclareMCP(t *testing.T) {
@@ -25,6 +28,71 @@ func TestRuntimeServiceMetadataDoesNotDeclareMCP(t *testing.T) {
 	}
 	if len(payload.Servers) != 0 {
 		t.Fatalf("Servers = %+v, want none without RuntimeServiceRef.MCP", payload.Servers)
+	}
+}
+
+func TestRuntimeServiceToolApprovalNormalizesAndFingerprintsAuthority(t *testing.T) {
+	server := MCPServerSpec{Key: "ui", Transport: MCPTransportHTTP, URL: "http://127.0.0.1/mcp", Tools: map[string]driver.MCPToolPolicy{
+		" ui_patch ": {ApprovalMode: driver.MCPToolApprovalApprove},
+		"ui_open":    {ApprovalMode: driver.MCPToolApprovalApprove},
+	}}
+	refs := []RuntimeServiceRef{{ID: "ui", MCP: &server}}
+	caps := MCPCapability{Supported: true, HTTP: true, ToolApprovals: true}
+
+	payload, err := resolveMCPPayloadWithRuntime(nil, nil, refs, caps)
+	if err != nil {
+		t.Fatalf("resolveMCPPayloadWithRuntime: %v", err)
+	}
+	want := map[string]driver.MCPToolPolicy{"ui_open": {ApprovalMode: driver.MCPToolApprovalApprove}, "ui_patch": {ApprovalMode: driver.MCPToolApprovalApprove}}
+	if got := payload.Servers[0].Tools; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Tools = %#v, want %#v", got, want)
+	}
+	server.Tools["shell"] = driver.MCPToolPolicy{ApprovalMode: driver.MCPToolApprovalApprove}
+	if got := payload.Servers[0].Tools; !reflect.DeepEqual(got, want) {
+		t.Fatalf("payload aliases caller: %#v", got)
+	}
+
+	reordered := MCPServerSpec{Key: "ui", Transport: MCPTransportHTTP, URL: "http://127.0.0.1/mcp", Tools: map[string]driver.MCPToolPolicy{
+		"ui_open": {ApprovalMode: driver.MCPToolApprovalApprove}, "ui_patch": {ApprovalMode: driver.MCPToolApprovalApprove},
+	}}
+	equivalent, err := resolveMCPPayloadWithRuntime(nil, nil, []RuntimeServiceRef{{MCP: &reordered}}, caps)
+	if err != nil {
+		t.Fatalf("resolve reordered policy: %v", err)
+	}
+	if equivalent.Fingerprint != payload.Fingerprint {
+		t.Fatalf("equivalent order changed fingerprint: %q != %q", equivalent.Fingerprint, payload.Fingerprint)
+	}
+
+	changedServer := reordered
+	changedServer.Tools = map[string]driver.MCPToolPolicy{"ui_open": {ApprovalMode: driver.MCPToolApprovalApprove}}
+	changed, err := resolveMCPPayloadWithRuntime(nil, nil, []RuntimeServiceRef{{MCP: &changedServer}}, caps)
+	if err != nil {
+		t.Fatalf("resolve changed policy: %v", err)
+	}
+	if changed.Fingerprint == payload.Fingerprint {
+		t.Fatal("approval authority change did not change MCP fingerprint")
+	}
+}
+
+func TestRuntimeServiceToolApprovalFailsClosed(t *testing.T) {
+	server := MCPServerSpec{Key: "ui", Transport: MCPTransportHTTP, URL: "http://127.0.0.1/mcp"}
+	tests := []struct {
+		name  string
+		tools map[string]driver.MCPToolPolicy
+		caps  MCPCapability
+	}{
+		{name: "blank tool", tools: map[string]driver.MCPToolPolicy{" ": {ApprovalMode: driver.MCPToolApprovalApprove}}, caps: MCPCapability{Supported: true, HTTP: true, ToolApprovals: true}},
+		{name: "invalid mode", tools: map[string]driver.MCPToolPolicy{"ui_open": {ApprovalMode: "always"}}, caps: MCPCapability{Supported: true, HTTP: true, ToolApprovals: true}},
+		{name: "unsupported driver", tools: map[string]driver.MCPToolPolicy{"ui_open": {ApprovalMode: driver.MCPToolApprovalApprove}}, caps: MCPCapability{Supported: true, HTTP: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server.Tools = tt.tools
+			_, err := resolveMCPPayloadWithRuntime(nil, nil, []RuntimeServiceRef{{MCP: &server}}, tt.caps)
+			if !errors.Is(err, ErrInvalidMCPConfig) && !errors.Is(err, ErrMCPUnsupported) {
+				t.Fatalf("error = %v, want fail-closed MCP sentinel", err)
+			}
+		})
 	}
 }
 

--- a/internal/mcpruntime/codex.go
+++ b/internal/mcpruntime/codex.go
@@ -29,7 +29,7 @@ func codexServerConfig(server driver.MCPServerSpec) (map[string]any, error) {
 		if len(server.Env) > 0 {
 			entry["env"] = cloneStringMapAny(server.Env)
 		}
-		return entry, nil
+		return codexToolApprovalConfig(entry, server.Tools), nil
 	case driver.MCPTransportHTTP:
 		if len(server.Headers) > 0 {
 			return nil, fmt.Errorf("%w: Codex MCP server %q does not support custom headers", engine.ErrInvalidMCPConfig, server.Key)
@@ -40,10 +40,22 @@ func codexServerConfig(server driver.MCPServerSpec) (map[string]any, error) {
 		if server.BearerTokenEnvVar != "" {
 			entry["bearer_token_env_var"] = server.BearerTokenEnvVar
 		}
-		return entry, nil
+		return codexToolApprovalConfig(entry, server.Tools), nil
 	default:
 		return nil, fmt.Errorf("%w: Codex MCP server %q does not support transport %q", engine.ErrMCPTransportUnsupported, server.Key, server.Transport)
 	}
+}
+
+func codexToolApprovalConfig(entry map[string]any, policies map[string]driver.MCPToolPolicy) map[string]any {
+	if len(policies) == 0 {
+		return entry
+	}
+	tools := make(map[string]any, len(policies))
+	for tool, policy := range policies {
+		tools[tool] = map[string]any{"approval_mode": string(policy.ApprovalMode)}
+	}
+	entry["tools"] = tools
+	return entry
 }
 
 func readTOMLObject(path string) (map[string]any, error) {

--- a/internal/mcpruntime/codex_test.go
+++ b/internal/mcpruntime/codex_test.go
@@ -175,3 +175,52 @@ wire_api = "responses"
 		t.Fatalf("empty unmanaged MCP sync rewrote config:\n%s", got)
 	}
 }
+
+func TestSyncCodexProjectsExactToolApprovalsAndPrunesStaleAuthority(t *testing.T) {
+	codexHome := t.TempDir()
+	payload := agentadaptor.MCPPayload{
+		Servers: []agentadaptor.MCPServerSpec{{
+			Key: "yangxia-agent-ui", Transport: agentadaptor.MCPTransportHTTP,
+			URL: "http://127.0.0.1:21901/mcp", BearerTokenEnvVar: "YANGXIA_RUN_TOKEN",
+			Tools: map[string]agentadaptor.MCPToolPolicy{
+				"yangxia_ui_close":       {ApprovalMode: agentadaptor.MCPToolApprovalApprove},
+				"yangxia_ui_open":        {ApprovalMode: agentadaptor.MCPToolApprovalApprove},
+				"yangxia_ui_patch":       {ApprovalMode: agentadaptor.MCPToolApprovalApprove},
+				"yangxia_ui_wait_action": {ApprovalMode: agentadaptor.MCPToolApprovalApprove},
+			},
+		}},
+	}
+	if _, err := SyncResource(context.Background(), "codex", codexHome, ProfileKindDedicated, payload); err != nil {
+		t.Fatalf("sync Codex approvals: %v", err)
+	}
+	configPath := filepath.Join(codexHome, "config.toml")
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	text := string(raw)
+	for tool := range payload.Servers[0].Tools {
+		if !strings.Contains(text, "[mcp_servers.yangxia-agent-ui.tools."+tool+"]") {
+			t.Fatalf("missing exact tool approval for %q:\n%s", tool, text)
+		}
+	}
+	if strings.Contains(text, "default_tools_approval_mode") || strings.Contains(text, "approval_policy") {
+		t.Fatalf("exact policy widened to server/global approval:\n%s", text)
+	}
+	if strings.Contains(text, "YANGXIA_SECRET_VALUE") {
+		t.Fatalf("secret value entered generated config:\n%s", text)
+	}
+
+	payload.Servers[0].Tools = nil
+	if _, err := SyncResource(context.Background(), "codex", codexHome, ProfileKindDedicated, payload); err != nil {
+		t.Fatalf("sync Codex without approvals: %v", err)
+	}
+	raw, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read pruned config: %v", err)
+	}
+	text = string(raw)
+	if strings.Contains(text, ".tools.") || strings.Contains(text, "approval_mode") {
+		t.Fatalf("stale exact-tool authority survived sync:\n%s", text)
+	}
+}

--- a/internal/mcpruntime/resource.go
+++ b/internal/mcpruntime/resource.go
@@ -97,7 +97,7 @@ func SyncResource(ctx context.Context, driverType, profileDir string, kind Profi
 	if err != nil {
 		return engine.ResourceSnapshot{}, err
 	}
-	desired, err := desiredServers(layout, payload.Servers)
+	desired, err := desiredServers(layout, payload)
 	if err != nil {
 		return engine.ResourceSnapshot{}, err
 	}
@@ -308,9 +308,9 @@ func writeStructuredRoot(layout providerLayout, root map[string]any) error {
 	}
 }
 
-func desiredServers(layout providerLayout, servers []driver.MCPServerSpec) (map[string]any, error) {
-	desired := make(map[string]any, len(servers))
-	for _, server := range servers {
+func desiredServers(layout providerLayout, payload driver.MCPPayload) (map[string]any, error) {
+	desired := make(map[string]any, len(payload.Servers))
+	for _, server := range payload.Servers {
 		if _, exists := desired[server.Key]; exists {
 			return nil, fmt.Errorf("mcp server %q is declared more than once", server.Key)
 		}

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -17,6 +17,12 @@ type Server = driver.MCPServerSpec
 // consumer-facing name for [driver.MCPTransport].
 type Transport = driver.MCPTransport
 
+// ToolApprovalMode is the provider-neutral approval mode for an exact tool.
+type ToolApprovalMode = driver.MCPToolApprovalMode
+
+// ToolPolicy is one exact MCP tool's policy.
+type ToolPolicy = driver.MCPToolPolicy
+
 // Re-exported transport values so Server literals and field checks do not
 // need a driver import.
 const (
@@ -26,6 +32,13 @@ const (
 	TransportHTTP = driver.MCPTransportHTTP
 	// TransportSSE connects to an SSE-based MCP endpoint.
 	TransportSSE = driver.MCPTransportSSE
+)
+
+const (
+	// ToolApprovalPrompt preserves an approval prompt for the exact tool.
+	ToolApprovalPrompt = driver.MCPToolApprovalPrompt
+	// ToolApprovalApprove authorizes only the exact tool on this server.
+	ToolApprovalApprove = driver.MCPToolApprovalApprove
 )
 
 // Option customizes a Server produced by [Stdio], [HTTP], or [SSE].
@@ -156,6 +169,24 @@ func Required(reason string) Option {
 	return func(server *Server) {
 		server.Required = true
 		server.RequiredReason = reason
+	}
+}
+
+// WithToolApproval sets the approval mode for one exact tool on this server.
+// Repeating an equivalent declaration is idempotent. A conflicting duplicate
+// is retained as an invalid closed-enum value so normal validation fails the
+// run before driver launch rather than silently choosing an order-dependent
+// winner.
+func WithToolApproval(name string, mode ToolApprovalMode) Option {
+	return func(server *Server) {
+		if server.Tools == nil {
+			server.Tools = make(map[string]ToolPolicy, 1)
+		}
+		policy := ToolPolicy{ApprovalMode: mode}
+		if existing, ok := server.Tools[name]; ok && existing != policy {
+			policy.ApprovalMode = ToolApprovalMode("conflict")
+		}
+		server.Tools[name] = policy
 	}
 }
 

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -159,6 +159,30 @@ func TestConstructorsCopyCallerInputs(t *testing.T) {
 	}
 }
 
+func TestWithToolApprovalSetsExactPolicy(t *testing.T) {
+	server := mcp.HTTP("ui", "http://127.0.0.1/mcp",
+		mcp.WithToolApproval("ui_open", mcp.ToolApprovalApprove),
+		mcp.WithToolApproval("ui_close", mcp.ToolApprovalPrompt),
+	)
+	want := map[string]driver.MCPToolPolicy{
+		"ui_open":  {ApprovalMode: driver.MCPToolApprovalApprove},
+		"ui_close": {ApprovalMode: driver.MCPToolApprovalPrompt},
+	}
+	if !reflect.DeepEqual(server.Tools, want) {
+		t.Fatalf("Tools = %#v, want %#v", server.Tools, want)
+	}
+}
+
+func TestWithToolApprovalConflictingDuplicateFailsClosed(t *testing.T) {
+	server := mcp.HTTP("ui", "http://127.0.0.1/mcp",
+		mcp.WithToolApproval("ui_open", mcp.ToolApprovalApprove),
+		mcp.WithToolApproval("ui_open", mcp.ToolApprovalPrompt),
+	)
+	if got := server.Tools["ui_open"].ApprovalMode; got == mcp.ToolApprovalApprove || got == mcp.ToolApprovalPrompt {
+		t.Fatalf("conflicting duplicate silently selected %q", got)
+	}
+}
+
 func TestOptionOrdering(t *testing.T) {
 	got := mcp.Stdio("repo-tools", "npx",
 		mcp.Args("first"),


### PR DESCRIPTION
Closes #24.

Adds a provider-neutral exact-tool approval policy on `MCPServerSpec` and projects it to Codex's native per-tool `approval_mode`. This fixes run-scoped authenticated MCP tools under normal `on-request` policy without changing global approval behavior.

Public API:

```go
mcp.WithToolApproval("yangxia_ui_open", mcp.ToolApprovalApprove)
```

Security boundaries:
- exact MCP server + exact tool map only; no glob/default-server mode;
- closed `prompt` / `approve` enum, normalized and validated pre-launch;
- unsupported drivers fail closed when policies are present;
- Codex renders only `[mcp_servers.<server>.tools.<tool>] approval_mode = ...`;
- `codex/appserver` server-request handling is unchanged, as are shell/file/permission/ordinary elicitation paths;
- no global `approvalPolicy = "never"`.

The policy is part of normalized MCP payload hashing, therefore changing it changes profile/runtime/thread resume compatibility; map ordering does not. Bearer secret values remain in `SecretEnv` and are not added to policy or generated TOML.

Validation:
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- API freeze golden updated intentionally

Base is PR #23 (`codex/fix-resume-stale-token-usage`) because the motivating run-scoped service flow and current consumer pin are based on commit `6432e5e4f727`.
